### PR TITLE
Add support for spot instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ module "ec2_cluster" {
 Examples
 --------
 
-* [Basic EC2 instance](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/tree/master/examples/basic)
+* [Basic EC2  instance](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/tree/master/examples/basic)
 
 Limitations
 -----------

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform module which creates EC2 instance(s) on AWS.
 
 These types of resources are supported:
 
-* [EC2 instance](https://www.terraform.io/docs/providers/aws/r/instance.html) 
+* [EC2 instance](https://www.terraform.io/docs/providers/aws/r/instance.html)
 
 Usage
 -----
@@ -16,12 +16,13 @@ module "ec2_cluster" {
 
   name  = "my-cluster"
   count = 5
-  
+
   ami                    = "ami-ebd02392"
   instance_type          = "t2.micro"
   key_name               = "user1"
   monitoring             = true
   vpc_security_group_ids = ["sg-12345678"]
+  spot_price             = "0.03"
 
   tags = {
     Terraform = "true"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -45,7 +45,7 @@ module "security_group" {
   egress_rules        = ["all-all"]
 }
 
-module "ec2" {
+module "ec2_spot" {
   source = "../../"
 
   name                        = "example"
@@ -53,4 +53,5 @@ module "ec2" {
   instance_type               = "t2.micro"
   vpc_security_group_ids      = ["${module.security_group.this_security_group_id}"]
   associate_public_ip_address = true
+  spot_price                  = "0.03"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 ######
 # EC2 instance
 ######
-resource "aws_instance" "this" {
+resource "aws_spot_instance" "this" {
   count = "${var.count}"
 
   ami                    = "${var.ami}"
@@ -30,6 +30,18 @@ resource "aws_instance" "this" {
   availability_zone                    = "${var.availability_zone}"
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
+
+  spot_price                      = "${var.spot_price}"
+  wait_for_fulfillment            = "${var.wait_for_fulfillment}"
+  spot_type                       = "${var.spot_type}"
+  instance_interruption_behaviour = "${var.instance_interruption_behaviour}"
+  launch_group                    = "${var.launch_group}"
+  block_duration_minutes          = "${var.block_duration_minutes}"
+
+  timeouts {
+    create = "${var.create_timeout}"
+    delete = "2${var.delete_timeout}h"
+  }
 
   # Note: network_interface can't be specified together with associate_public_ip_address
   # network_interface = "${var.network_interface}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -62,3 +62,38 @@ output "subnet_id" {
   description = "List of IDs of VPC subnets of instances"
   value       = ["${aws_instance.this.*.}"]
 }
+
+output "spot_bid_status" {
+  description = "The current bid status of the Spot Instance Request."
+  value       = ["${aws_instance.this.*.spot_bid_status}"]
+}
+
+output "spot_request_state" {
+  description = "The current request state of the Spot Instance Request."
+  value       = ["${aws_instance.this.*.spot_request_state}"]
+}
+
+output "spot_instance_id" {
+  description = "The Instance ID (if any) that is currently fulfilling the Spot Instance request."
+  value       = ["${aws_instance.this.*.spot_instance_id}"]
+}
+
+output "public_dns" {
+  description = "The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC"
+  value       = ["${aws_instance.this.*.public_dns}"]
+}
+
+output "public_ip" {
+  description = "The public IP address assigned to the instance, if applicable."
+  value       = ["${aws_instance.this.*.public_ip}"]
+}
+
+output "private_dns" {
+  description = "The private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC"
+  value       = ["${aws_instance.this.*.private_dns}"]
+}
+
+output "private_ip" {
+  description = "The private IP address assigned to the instance"
+  value       = ["${aws_instance.this.*.private_ip}"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -138,17 +138,19 @@ variable "spot_price" {
 variable "launch_group" {
   type        = "string"
   description = "Group name to assign the instances to so they can be started/stopped in unison, e.g. purple-plutonium"
-  default     = "defaulted"
+  default     = "default"
 }
 
 variable "instance_interruption_behaviour" {
   type        = "string"
   description = "Whether a Spot instance stops or terminates when it is interrupted, can be stop or terminate"
+  default     = "terminates"
 }
 
 variable "block_duration_minutes" {
   type        = "string"
   description = "(Optional) The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360)."
+  default     = "60"
 }
 
 variable "spot_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -154,12 +154,15 @@ variable "block_duration_minutes" {
 variable "spot_type" {
   type        = "string"
   description = "(Optional; Default: 'persistent') If set to 'one-time', after the instance is terminated, the spot request will be closed. Also, Terraform can't manage one-time spot requests, just launch them."
+  default     = "persistent"
 }
 
 variable "create_timeout" {
   description = "(Defaults to 10 mins) Used when requesting the spot instance (only valid if wait_for_fulfillment = true)"
+  default     = "10"
 }
 
 variable "delete_timeout" {
   description = "(Defaults to 10 mins) Used when terminating all instances launched via the given spot instance request"
+  default     = "10"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -133,6 +133,7 @@ variable "network_interface" {
 variable "spot_price" {
   type        = "string"
   description = "The maximum hourly price (bid) you are willing to pay for the instance, e.g. 0.10"
+  default     = "0.01"
 }
 
 variable "launch_group" {
@@ -144,13 +145,13 @@ variable "launch_group" {
 variable "instance_interruption_behaviour" {
   type        = "string"
   description = "Whether a Spot instance stops or terminates when it is interrupted, can be stop or terminate"
-  default     = "terminates"
+  default     = "terminate"
 }
 
 variable "block_duration_minutes" {
   type        = "string"
   description = "(Optional) The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360)."
-  default     = "60"
+  default     = 60
 }
 
 variable "spot_type" {
@@ -161,10 +162,10 @@ variable "spot_type" {
 
 variable "create_timeout" {
   description = "(Defaults to 10 mins) Used when requesting the spot instance (only valid if wait_for_fulfillment = true)"
-  default     = "10"
+  default     = 10
 }
 
 variable "delete_timeout" {
   description = "(Defaults to 10 mins) Used when terminating all instances launched via the given spot instance request"
-  default     = "10"
+  default     = 10
 }

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,37 @@ variable "network_interface" {
   description = "Customize network interfaces to be attached at instance boot time"
   default     = []
 }
+
+variable "spot_price" {
+  type        = "string"
+  description = "The maximum hourly price (bid) you are willing to pay for the instance, e.g. 0.10"
+}
+
+variable "launch_group" {
+  type        = "string"
+  description = "Group name to assign the instances to so they can be started/stopped in unison, e.g. purple-plutonium"
+  default     = "defaulted"
+}
+
+variable "instance_interruption_behaviour" {
+  type        = "string"
+  description = "Whether a Spot instance stops or terminates when it is interrupted, can be stop or terminate"
+}
+
+variable "block_duration_minutes" {
+  type        = "string"
+  description = "(Optional) The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360)."
+}
+
+variable "spot_type" {
+  type        = "string"
+  description = "(Optional; Default: 'persistent') If set to 'one-time', after the instance is terminated, the spot request will be closed. Also, Terraform can't manage one-time spot requests, just launch them."
+}
+
+variable "create_timeout" {
+  description = "(Defaults to 10 mins) Used when requesting the spot instance (only valid if wait_for_fulfillment = true)"
+}
+
+variable "delete_timeout" {
+  description = "(Defaults to 10 mins) Used when terminating all instances launched via the given spot instance request"
+}


### PR DESCRIPTION
Follow up to #4

To-do:
- [ ] Add separate example which runs spot-instance. Keep existing as it was (revert your change).
- [ ] Update defaults specified in `variables.tf`, so that by default this module created on-demand instances (as before)
- [ ] Review all configurable parameters. Now not all of them are in variables.tf (eg, `wait_for_fulfillment`)
- [ ] "Thank you" goes to @johnypony3 :)

@johnypony3 Can you fix these?