### PR TITLE
Fix incorrect subnet_id output expression

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -60,5 +60,5 @@ output "vpc_security_group_ids" {
 
 output "subnet_id" {
   description = "List of IDs of VPC subnets of instances"
-  value       = ["${aws_instance.this.*.}"]
+  value       = ["${aws_instance.this.*.subnet_id}"]
 }


### PR DESCRIPTION
This was always producing an error, but prior to Terraform 0.11 these errors were suppressed and shown only in the logs.

Now that Terraform 0.11 shows errors in outputs, they must all be valid in order to use this module.