### PR TITLE
Allow passing list for subnet and user_data

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,8 @@ resource "aws_instance" "this" {
   ami                    = "${var.ami}"
   instance_type          = "${var.instance_type}"
   user_data              = "${var.user_data}"
-  subnet_id              = "${var.subnet_id}"
+  user_data              = "${element(var.user_data, count.index)}"
+  subnet_id              = "${element(var.subnet_id, count.index)}"
   key_name               = "${var.key_name}"
   monitoring             = "${var.monitoring}"
   vpc_security_group_ids = ["${var.vpc_security_group_ids}"]

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,7 @@ variable "vpc_security_group_ids" {
 
 variable "subnet_id" {
   description = "The VPC Subnet ID to launch in"
+  default = []
 }
 
 variable "associate_public_ip_address" {
@@ -76,7 +77,7 @@ variable "source_dest_check" {
 
 variable "user_data" {
   description = "The user data to provide when launching the instance"
-  default     = ""
+  default     = []
 }
 
 variable "iam_instance_profile" {

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "vpc_security_group_ids" {
 
 variable "subnet_id" {
   description = "The VPC Subnet ID to launch in"
-  default = []
+  type        = "list"
 }
 
 variable "associate_public_ip_address" {
@@ -78,6 +78,7 @@ variable "source_dest_check" {
 variable "user_data" {
   description = "The user data to provide when launching the instance"
   default     = []
+  type        = "list"
 }
 
 variable "iam_instance_profile" {


### PR DESCRIPTION
Hi,

Thank you for writing this module, very useful.

I used it but I needed to create ec2 instance across multiple subnets and also pass different user_data templates.
In the current version we can't because these 2 variables are string.

I propose this PR to fix this, by allowing to pass list for subnet_id and user_data.

