### PR TITLE
Ignore ebs_block_device

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,6 @@ resource "aws_instance" "this" {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = ["private_ip", "vpc_security_group_ids", "root_block_device"]
+    ignore_changes = ["private_ip", "vpc_security_group_ids", "root_block_device", "ebs_block_device"]
   }
 }


### PR DESCRIPTION
When I tried to use this module with some additional resources, I faced this issue:

`null_resource` for provision failed and Terraform planned to re-deploy all resources on the next run.

Terraform version: `Terraform v0.11.2`

I fixed it locally by adding `ebs_block_device` to the lifecycle ignore list (I have EBS attached to my instance). However, I'm not sure if it's a proper fix. I haven't dug deep into this bug, though.

Also, I believe, that `ebs_block_device` and `root_block_device` should be maps, but I'm not sure