### PR TITLE
Modify tag name management to add -%d suffixe only if instance_count > 1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_instance" "this" {
   # Note: network_interface can't be specified together with associate_public_ip_address
   # network_interface = "${var.network_interface}"
 
-  tags = "${merge(var.tags, map("Name", format("%s-%d", var.name, count.index+1)))}"
+  tags = "${merge(var.tags, map("Name", var.instance_count > 1 ? format("%s-%d", var.name, count.index+1):var.name))}"
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)


### PR DESCRIPTION
Hello, Anton

I modified the name tag merge to prevent adding suffix in case of only 1 instance is deployed, it may be usefull for non cluster deployement.

Thks

Regards