### PR TITLE
Stop ignoring changes in vpc_security_group_ids

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,6 @@ resource "aws_instance" "this" {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = ["private_ip", "vpc_security_group_ids", "root_block_device"]
+    ignore_changes = ["private_ip", "root_block_device"]
   }
 }


### PR DESCRIPTION
- Removes `vpc_security_group_ids` argument from `ignore_changes` lifecycle parameter

`vpc_security_group_ids` was added to `ignore_changes` lifecycle due to #10 and several known issues in Terraform AWS provider related to arguments of aws_instance (https://github.com/terraform-providers/terraform-provider-aws/issues/2036). 
The corresponding issue has been fixed in Terraform AWS provider [v1.9.0](https://github.com/terraform-providers/terraform-provider-aws/releases/tag/v1.9.0) (see https://github.com/terraform-providers/terraform-provider-aws/pull/2338).