### PR TITLE
allow subnet_id to take a comma-separated list

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_instance" "this" {
   ami                    = "${var.ami}"
   instance_type          = "${var.instance_type}"
   user_data              = "${var.user_data}"
-  subnet_id              = "${var.subnet_id}"
+  subnet_id              = "${element(split(",", var.subnet_id), count.index)}"
   key_name               = "${var.key_name}"
   monitoring             = "${var.monitoring}"
   vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
@@ -50,7 +50,7 @@ resource "aws_instance" "this_t2" {
   ami                    = "${var.ami}"
   instance_type          = "${var.instance_type}"
   user_data              = "${var.user_data}"
-  subnet_id              = "${var.subnet_id}"
+  subnet_id              = "${element(split(",", var.subnet_id), count.index)}"
   key_name               = "${var.key_name}"
   monitoring             = "${var.monitoring}"
   vpc_security_group_ids = ["${var.vpc_security_group_ids}"]

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "vpc_security_group_ids" {
 }
 
 variable "subnet_id" {
-  description = "The VPC Subnet ID to launch in"
+  description = "The VPC Subnet ID to launch in. A comma-separated list may be passed to be used with instance_count."
 }
 
 variable "associate_public_ip_address" {


### PR DESCRIPTION
If you want to use instance_count to create multiple copies of the same aws_instance, you may also want to have those instances automatically spread out across multiple subnets. Terraform provides this functionality by using the count.index dynamic variable to loop over a list, but you can't reference a count variable when passing arguments to a module (it can only be used within the resource itself). This change allows you to pass multiple subnets to the module as a comma-separated list.

---

Because Terraform variables are strictly typed, I couldn't make subnet_id take a list without breaking existing usage of the module, so it had to remain a string. I thought about adding a second variable, "subnet_ids", that takes a list, but then I would have had to provide a default to both variables in order to allow one to be left out, and that would have created the surprising behavior of a required field not being required (Terraform has no way to say you must set one of these two variables). The best option remaining was to make it accept lists in the form of a comma-separated string, a pattern which has already seen use in other places in the Terraform Registry, e.g. ingress_with_cidr_blocks in terraform-aws-modules/security-group/aws.