### PR TITLE
Narrow t2 selection criteria.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  is_t2_instance_type = "${replace(replace(var.instance_type, "/^[^t2].*/", "0"), "/^t2.*$/", "1")}"
+  is_t2_instance_type = "${replace(var.instance_type, "/^t2\\..*$/", "1") == "1" ? "1" : "0"}"
 }
 
 ######


### PR DESCRIPTION
This narrows the match for things considered to be t2 instances to only
those types that start with "t2.". Previously there was a class of
(invalid) instance types, such as "2b.something" or "t5.something" that
would cause an error on boolean parsing by matching one regex and not
the other.

This uses conditional logic to identify the non-t2 case, since I don't have a good method for implementing the inverse regular expression without negative lookahead assertions, which re2 doesn't support.