### PR TITLE
Ignore changes in the ebs_block_device

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_instance" "this" {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = ["private_ip", "root_block_device"]
+    ignore_changes = ["private_ip", "root_block_device", "ebs_block_device"]
   }
 }
 
@@ -83,6 +83,6 @@ resource "aws_instance" "this_t2" {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = ["private_ip", "root_block_device"]
+    ignore_changes = ["private_ip", "root_block_device", "ebs_block_device"]
   }
 }


### PR DESCRIPTION
Any change in the ebs block device currently triggers re-creation of
this resource which I assume is not intended. In turn any attached
block device will also be re-created because the instance is re-created
creating a loop of re-created resources for each time terraform is
applied.

Workaround by ignoring these changes as suggested in:

https://github.com/terraform-providers/terraform-provider-aws/issues/1297#issuecomment-319359965