### PR TITLE
Removed volume tag from root volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ data "aws_ami" "ubuntu-xenial" {
 | tags | A mapping of tags to assign to the resource | string | `<map>` | no |
 | tenancy | The tenancy of the instance (if the instance is running in a VPC). Available values: default, dedicated, host. | string | `default` | no |
 | user_data | The user data to provide when launching the instance | string | `` | no |
-| volume_tags | A mapping of tags to assign to the devices created by the instance at launch time | string | `<map>` | no |
 | vpc_security_group_ids | A list of security group IDs to associate with | list | - | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,6 @@ resource "aws_instance" "this" {
   ipv6_addresses              = "${var.ipv6_addresses}"
 
   ebs_optimized          = "${var.ebs_optimized}"
-  volume_tags            = "${var.volume_tags}"
   root_block_device      = "${var.root_block_device}"
   ebs_block_device       = "${var.ebs_block_device}"
   ephemeral_block_device = "${var.ephemeral_block_device}"
@@ -62,7 +61,6 @@ resource "aws_instance" "this_t2" {
   ipv6_addresses              = "${var.ipv6_addresses}"
 
   ebs_optimized          = "${var.ebs_optimized}"
-  volume_tags            = "${var.volume_tags}"
   root_block_device      = "${var.root_block_device}"
   ebs_block_device       = "${var.ebs_block_device}"
   ephemeral_block_device = "${var.ephemeral_block_device}"

--- a/variables.tf
+++ b/variables.tf
@@ -99,11 +99,6 @@ variable "tags" {
   default     = {}
 }
 
-variable "volume_tags" {
-  description = "A mapping of tags to assign to the devices created by the instance at launch time"
-  default     = {}
-}
-
 variable "root_block_device" {
   description = "Customize details about the root block device of the instance. See Block Devices below for details"
   default     = []


### PR DESCRIPTION
Removed volume tag from ec2 instance. This modify permit to tag ebs volume attached to the ec2 instance without conflicts.
A terraform bug create conflict between tag  of root volume (defined on the ec2 resource) and ebs tag.