### PR TITLE
Make number of instances created configurable, defaulting to 1

### DIFF
--- a/examples/volume-attachment/main.tf
+++ b/examples/volume-attachment/main.tf
@@ -49,7 +49,7 @@ module "security_group" {
 module "ec2" {
   source = "../../"
 
-  instance_count = 1
+  instance_count = "${var.instances_number}"
 
   name                        = "example-with-ebs"
   ami                         = "${data.aws_ami.amazon_linux.id}"
@@ -60,12 +60,16 @@ module "ec2" {
 }
 
 resource "aws_volume_attachment" "this_ec2" {
+  count = "${var.instances_number}"
+
   device_name = "/dev/sdh"
-  volume_id   = "${aws_ebs_volume.this.id}"
-  instance_id = "${module.ec2.id[0]}"
+  volume_id   = "${aws_ebs_volume.this.*.id[count.index]}"
+  instance_id = "${module.ec2.id[count.index]}"
 }
 
 resource "aws_ebs_volume" "this" {
-  availability_zone = "${module.ec2.availability_zone[0]}"
+  count = "${var.instances_number}"
+
+  availability_zone = "${module.ec2.availability_zone[count.index]}"
   size              = 1
 }

--- a/examples/volume-attachment/outputs.tf
+++ b/examples/volume-attachment/outputs.tf
@@ -1,19 +1,14 @@
-output "instance_id" {
-  description = "EC2 instance ID"
-  value       = "${module.ec2.id[0]}"
-}
-
-output "instance_public_dns" {
-  description = "Public DNS name assigned to the EC2 instance"
-  value       = "${module.ec2.public_dns[0]}"
+output "instances_public_ips" {
+  description = "Public IPs assigned to the EC2 instance"
+  value       = "${module.ec2.public_ip}"
 }
 
 output "ebs_volume_attachment_id" {
   description = "The volume ID"
-  value       = "${aws_volume_attachment.this_ec2.volume_id}"
+  value       = "${aws_volume_attachment.this_ec2.*.volume_id}"
 }
 
 output "ebs_volume_attachment_instance_id" {
   description = "The instance ID"
-  value       = "${aws_volume_attachment.this_ec2.instance_id}"
+  value       = "${aws_volume_attachment.this_ec2.*.instance_id}"
 }

--- a/examples/volume-attachment/variables.tf
+++ b/examples/volume-attachment/variables.tf
@@ -1,0 +1,3 @@
+variable "instances_number" {
+  default = 1
+}


### PR DESCRIPTION
I have to remote the output "instance_id" because I do not know how to iterate from variables created from modules

Related with #49