### PR TITLE
network_interface_id Attribute Removal

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,6 @@ locals {
   this_key_name                     = "${compact(concat(coalescelist(aws_instance.this.*.key_name, aws_instance.this_t2.*.key_name), list("")))}"
   this_public_dns                   = "${compact(concat(coalescelist(aws_instance.this.*.public_dns, aws_instance.this_t2.*.public_dns), list("")))}"
   this_public_ip                    = "${compact(concat(coalescelist(aws_instance.this.*.public_ip, aws_instance.this_t2.*.public_ip), list("")))}"
-  this_network_interface_id         = "${compact(concat(coalescelist(aws_instance.this.*.network_interface_id, aws_instance.this_t2.*.network_interface_id), list("")))}"
   this_primary_network_interface_id = "${compact(concat(coalescelist(aws_instance.this.*.primary_network_interface_id, aws_instance.this_t2.*.primary_network_interface_id), list("")))}"
   this_private_dns                  = "${compact(concat(coalescelist(aws_instance.this.*.private_dns, aws_instance.this_t2.*.private_dns), list("")))}"
   this_private_ip                   = "${compact(concat(coalescelist(aws_instance.this.*.private_ip, aws_instance.this_t2.*.private_ip), list("")))}"
@@ -44,11 +43,6 @@ output "public_dns" {
 output "public_ip" {
   description = "List of public IP addresses assigned to the instances, if applicable"
   value       = ["${local.this_public_ip}"]
-}
-
-output "network_interface_id" {
-  description = "List of IDs of the network interface of instances"
-  value       = ["${local.this_network_interface_id}"]
 }
 
 output "primary_network_interface_id" {


### PR DESCRIPTION
**Description**
https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/issues/75
The network_interface_id attribute is being removed, switch your attribute references to the primary_network_interface_id attribute instead.

Reference:
https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#resource-aws_instance
https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#network_interface_id-attribute-removal

@antonbabenko @den-is 
