### PR TITLE
Add missing required field

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -15,7 +15,8 @@ data "aws_subnet_ids" "all" {
 
 data "aws_ami" "amazon_linux" {
   most_recent = true
-
+  owners = ['amazon']
+  
   filter {
     name = "name"
 


### PR DESCRIPTION
Field `owners` is required for `aws_ami`, otherwise it fails.