### PR TITLE
Add volume tags naming and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ data "aws_ami" "ubuntu-xenial" {
 | security\_groups | List of associated security groups of instances |
 | subnet\_id | List of IDs of VPC subnets of instances |
 | tags | List of tags of instances |
+| volume\_tags | List of tags of volumes of instances |
 | vpc\_security\_group\_ids | List of associated security groups of instances, if running in non-default VPC |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,6 @@ resource "aws_instance" "this" {
   ipv6_addresses              = "${var.ipv6_addresses}"
 
   ebs_optimized          = "${var.ebs_optimized}"
-  volume_tags            = "${var.volume_tags}"
   root_block_device      = "${var.root_block_device}"
   ebs_block_device       = "${var.ebs_block_device}"
   ephemeral_block_device = "${var.ephemeral_block_device}"
@@ -34,7 +33,8 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  tags        = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  volume_tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.volume_tags)}"
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
@@ -62,7 +62,6 @@ resource "aws_instance" "this_t2" {
   ipv6_addresses              = "${var.ipv6_addresses}"
 
   ebs_optimized          = "${var.ebs_optimized}"
-  volume_tags            = "${var.volume_tags}"
   root_block_device      = "${var.root_block_device}"
   ebs_block_device       = "${var.ebs_block_device}"
   ephemeral_block_device = "${var.ephemeral_block_device}"
@@ -77,7 +76,8 @@ resource "aws_instance" "this_t2" {
     cpu_credits = "${var.cpu_credits}"
   }
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  tags        = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  volume_tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.volume_tags)}"
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,6 +12,7 @@ locals {
   this_subnet_id                    = "${compact(concat(coalescelist(aws_instance.this.*.subnet_id, aws_instance.this_t2.*.subnet_id), list("")))}"
   this_credit_specification         = "${aws_instance.this_t2.*.credit_specification}"
   this_tags                         = "${coalescelist(flatten(aws_instance.this.*.tags), flatten(aws_instance.this_t2.*.tags))}"
+  this_volume_tags                  = "${coalescelist(flatten(aws_instance.this.*.volume_tags), flatten(aws_instance.this_t2.*.volume_tags))}"
 }
 
 output "id" {
@@ -83,4 +84,9 @@ output "credit_specification" {
 output "tags" {
   description = "List of tags of instances"
   value       = ["${local.this_tags}"]
+}
+
+output "volume_tags" {
+  description = "List of tags of volumes of instances"
+  value       = ["${local.this_volume_tags}"]
 }


### PR DESCRIPTION
According to issue #79, I add `volume_tags` in output.tf.
Additionally, I add a same naming policy on `volume_tags`. 
I think Issue #60 should be solved by some other effective ways so I don't use the workaround in [here](https://github.com/terraform-providers/terraform-provider-aws/issues/770#issuecomment-348564510). Maybe we can have further discussion.