### PR TITLE
Ignores volume_tags to preserve idempotency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_instance" "this" {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = ["private_ip", "root_block_device", "ebs_block_device"]
+    ignore_changes = ["volume_tags", "private_ip", "root_block_device", "ebs_block_device"]
   }
 }
 
@@ -83,6 +83,6 @@ resource "aws_instance" "this_t2" {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = ["private_ip", "root_block_device", "ebs_block_device"]
+    ignore_changes = ["volume_tags", "private_ip", "root_block_device", "ebs_block_device"]
   }
 }


### PR DESCRIPTION
To fix https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/issues/60. To avoid the race condition: `aws_ebs_volume` tags (defined outside the module) are overrided by `volume_tags` of the module.

Unfortunalty lifecycle `ignore_changes` does not accept variables, so it cannot be specified by end user.