### PR TITLE
Uses 2 digits suffixes for instances instead of 1 digit suffix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%02d", var.name, count.index+1) : var.name), var.tags)}"
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
@@ -77,7 +77,7 @@ resource "aws_instance" "this_t2" {
     cpu_credits = "${var.cpu_credits}"
   }
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%02d", var.name, count.index+1) : var.name), var.tags)}"
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:


### PR DESCRIPTION
Here is the reasoning behind this feature:
While it’s fairly infrequent, it happens to want to create 10+ instances. Even if the actual module will work correctly, names will eventually differ in size. e.g.:
```
[…]
instance-name-9
instance-name-10
[…]
```

For the sake of cleanliness and to ease the work of system administrator who deals with instances names, this PR would make sure name have the same length:

```
[…]
instance-name-09
instance-name-10
[…]
```

Now, why not 3 or 4 digits? I think it is very unlikely to have more than 100 instances of the same type and most team would scale vertically or use containers at some point.
