### PR TITLE
Expose format as a variable you can override for instance name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", lower(var.name), count.index+1) : lower(var.name)), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", lower(var.name), count.index+1) : lower(var.name)), var.tags)}"
+tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", lower(var.name), count.index+1) : lower(var.name)), var.tags)}"
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 locals {
   is_t_instance_type = "${replace(var.instance_type, "/^t[23]{1}\\..*$/", "1") == "1" ? "1" : "0"}"
-  name = (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", var.name, count.index+1) : var.name)
 }
 
 ######
@@ -35,14 +34,8 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-#tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", lower(var.name), count.index+1) : lower(var.name)), var.tags)}"
-  tags = "${merge(
-    map(
-        "Name", local.name,
-        "ellevation:Name", lower(local.name),
-    ),
-    var.tags
-)}"
+tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", lower(var.name), count.index+1) : lower(var.name)), var.tags)}"
+
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", lower(var.name), count.index+1) : lower(var.name)), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", lower(var.name), count.index+1) : lower(var.name)), var.tags)}"
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format(var.name_with_num_format, var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", lower(var.name), count.index+1) : lower(var.name)), var.tags)}"
+tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format(var.name_with_num_format, var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format(var.name_with_num_format, lower(var.name), count.index+1) : lower(var.name)), var.tags)}"
 
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format(var.name_with_num_format, var.name, count.index+1) : var.name), var.tags)}"
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:

--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ resource "aws_instance" "this_t2" {
     cpu_credits = "${var.cpu_credits}"
   }
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format(var.name_with_num_format, var.name, count.index+1) : var.name), var.tags)}"
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", lower(var.name), count.index+1) : lower(var.name)), var.tags)}"
+tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format(var.name_with_num_format, var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s0%d", lower(var.name), count.index+1) : lower(var.name)), var.tags)}"
 
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+tags =  "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)

--- a/main.tf
+++ b/main.tf
@@ -34,8 +34,7 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format(var.name_with_num_format, var.name, count.index+1) : var.name), var.tags)}"
-
+tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags, map("ellevation:Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)

--- a/variables.tf
+++ b/variables.tf
@@ -140,3 +140,8 @@ variable "use_num_suffix" {
   description = "Always append numerical suffix to instance name, even if instance_count is 1"
   default     = "false"
 }
+
+variable "name_with_num_format" {
+  description = "Format string for instance name when using count"
+  default     = "%s-%d"
+}


### PR DESCRIPTION
Rather than hard-code it to name-count, allow the user to override it to
provide their own format.