### PR TITLE
Update the code to support terraform v0.12.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,88 +1,165 @@
 locals {
-  is_t_instance_type = "${replace(var.instance_type, "/^t[23]{1}\\..*$/", "1") == "1" ? "1" : "0"}"
+  is_t_instance_type = replace(var.instance_type, "/^t[23]{1}\\..*$/", "1") == "1" ? "1" : "0"
 }
 
 ######
 # Note: network_interface can't be specified together with associate_public_ip_address
 ######
 resource "aws_instance" "this" {
-  count = "${var.instance_count * (1 - local.is_t_instance_type)}"
+  count = var.instance_count * 1 - local.is_t_instance_type
 
-  ami                    = "${var.ami}"
-  instance_type          = "${var.instance_type}"
-  user_data              = "${var.user_data}"
-  subnet_id              = "${element(distinct(compact(concat(list(var.subnet_id), var.subnet_ids))),count.index)}"
-  key_name               = "${var.key_name}"
-  monitoring             = "${var.monitoring}"
-  vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
-  iam_instance_profile   = "${var.iam_instance_profile}"
+  ami           = var.ami
+  instance_type = var.instance_type
+  user_data     = var.user_data
+  subnet_id = element(
+    distinct(compact(concat([var.subnet_id], var.subnet_ids))),
+    count.index,
+  )
+  key_name               = var.key_name
+  monitoring             = var.monitoring
+  vpc_security_group_ids = var.vpc_security_group_ids
+  iam_instance_profile   = var.iam_instance_profile
 
-  associate_public_ip_address = "${var.associate_public_ip_address}"
-  private_ip                  = "${var.private_ip}"
-  ipv6_address_count          = "${var.ipv6_address_count}"
-  ipv6_addresses              = "${var.ipv6_addresses}"
+  associate_public_ip_address = var.associate_public_ip_address
+  private_ip                  = var.private_ip
+  ipv6_address_count          = var.ipv6_address_count
+  ipv6_addresses              = var.ipv6_addresses
 
-  ebs_optimized          = "${var.ebs_optimized}"
-  volume_tags            = "${var.volume_tags}"
-  root_block_device      = "${var.root_block_device}"
-  ebs_block_device       = "${var.ebs_block_device}"
-  ephemeral_block_device = "${var.ephemeral_block_device}"
+  ebs_optimized = var.ebs_optimized
+  volume_tags   = var.volume_tags
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+    content {
+      delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
+      iops                  = lookup(root_block_device.value, "iops", null)
+      volume_size           = lookup(root_block_device.value, "volume_size", null)
+      volume_type           = lookup(root_block_device.value, "volume_type", null)
+    }
+  }
+  dynamic "ebs_block_device" {
+    for_each = var.ebs_block_device
+    content {
+      delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", null)
+      device_name           = ebs_block_device.value.device_name
+      encrypted             = lookup(ebs_block_device.value, "encrypted", null)
+      iops                  = lookup(ebs_block_device.value, "iops", null)
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
+      volume_size           = lookup(ebs_block_device.value, "volume_size", null)
+      volume_type           = lookup(ebs_block_device.value, "volume_type", null)
+    }
+  }
+  dynamic "ephemeral_block_device" {
+    for_each = var.ephemeral_block_device
+    content {
+      device_name  = ephemeral_block_device.value.device_name
+      no_device    = lookup(ephemeral_block_device.value, "no_device", null)
+      virtual_name = lookup(ephemeral_block_device.value, "virtual_name", null)
+    }
+  }
 
-  source_dest_check                    = "${var.source_dest_check}"
-  disable_api_termination              = "${var.disable_api_termination}"
-  instance_initiated_shutdown_behavior = "${var.instance_initiated_shutdown_behavior}"
-  placement_group                      = "${var.placement_group}"
-  tenancy                              = "${var.tenancy}"
+  source_dest_check                    = var.source_dest_check
+  disable_api_termination              = var.disable_api_termination
+  instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
+  placement_group                      = var.placement_group
+  tenancy                              = var.tenancy
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  tags = merge(
+    {
+      "Name" = var.instance_count > 1 || var.use_num_suffix == "true" ? format("%s-%d", var.name, count.index + 1) : var.name
+    },
+    var.tags,
+  )
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = ["private_ip", "root_block_device", "ebs_block_device"]
+    ignore_changes = [
+      private_ip,
+      root_block_device,
+      ebs_block_device,
+    ]
   }
 }
 
 resource "aws_instance" "this_t2" {
-  count = "${var.instance_count * local.is_t_instance_type}"
+  count = var.instance_count * local.is_t_instance_type
 
-  ami                    = "${var.ami}"
-  instance_type          = "${var.instance_type}"
-  user_data              = "${var.user_data}"
-  subnet_id              = "${element(distinct(compact(concat(list(var.subnet_id), var.subnet_ids))),count.index)}"
-  key_name               = "${var.key_name}"
-  monitoring             = "${var.monitoring}"
-  vpc_security_group_ids = ["${var.vpc_security_group_ids}"]
-  iam_instance_profile   = "${var.iam_instance_profile}"
+  ami           = var.ami
+  instance_type = var.instance_type
+  user_data     = var.user_data
+  subnet_id = element(
+    distinct(compact(concat([var.subnet_id], var.subnet_ids))),
+    count.index,
+  )
+  key_name               = var.key_name
+  monitoring             = var.monitoring
+  vpc_security_group_ids = var.vpc_security_group_ids
+  iam_instance_profile   = var.iam_instance_profile
 
-  associate_public_ip_address = "${var.associate_public_ip_address}"
-  private_ip                  = "${var.private_ip}"
-  ipv6_address_count          = "${var.ipv6_address_count}"
-  ipv6_addresses              = "${var.ipv6_addresses}"
+  associate_public_ip_address = var.associate_public_ip_address
+  private_ip                  = var.private_ip
+  ipv6_address_count          = var.ipv6_address_count
+  ipv6_addresses              = var.ipv6_addresses
 
-  ebs_optimized          = "${var.ebs_optimized}"
-  volume_tags            = "${var.volume_tags}"
-  root_block_device      = "${var.root_block_device}"
-  ebs_block_device       = "${var.ebs_block_device}"
-  ephemeral_block_device = "${var.ephemeral_block_device}"
-
-  source_dest_check                    = "${var.source_dest_check}"
-  disable_api_termination              = "${var.disable_api_termination}"
-  instance_initiated_shutdown_behavior = "${var.instance_initiated_shutdown_behavior}"
-  placement_group                      = "${var.placement_group}"
-  tenancy                              = "${var.tenancy}"
-
-  credit_specification {
-    cpu_credits = "${var.cpu_credits}"
+  ebs_optimized = var.ebs_optimized
+  volume_tags   = var.volume_tags
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+    content {
+      delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
+      iops                  = lookup(root_block_device.value, "iops", null)
+      volume_size           = lookup(root_block_device.value, "volume_size", null)
+      volume_type           = lookup(root_block_device.value, "volume_type", null)
+    }
+  }
+  dynamic "ebs_block_device" {
+    for_each = var.ebs_block_device
+    content {
+      delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", null)
+      device_name           = ebs_block_device.value.device_name
+      encrypted             = lookup(ebs_block_device.value, "encrypted", null)
+      iops                  = lookup(ebs_block_device.value, "iops", null)
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
+      volume_size           = lookup(ebs_block_device.value, "volume_size", null)
+      volume_type           = lookup(ebs_block_device.value, "volume_type", null)
+    }
+  }
+  dynamic "ephemeral_block_device" {
+    for_each = var.ephemeral_block_device
+    content {
+      device_name  = ephemeral_block_device.value.device_name
+      no_device    = lookup(ephemeral_block_device.value, "no_device", null)
+      virtual_name = lookup(ephemeral_block_device.value, "virtual_name", null)
+    }
   }
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  source_dest_check                    = var.source_dest_check
+  disable_api_termination              = var.disable_api_termination
+  instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
+  placement_group                      = var.placement_group
+  tenancy                              = var.tenancy
+
+  credit_specification {
+    cpu_credits = var.cpu_credits
+  }
+
+  tags = merge(
+    {
+      "Name" = var.instance_count > 1 || var.use_num_suffix == "true" ? format("%s-%d", var.name, count.index + 1) : var.name
+    },
+    var.tags,
+  )
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
     # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
     # we have to ignore changes in the following arguments
-    ignore_changes = ["private_ip", "root_block_device", "ebs_block_device"]
+    ignore_changes = [
+      private_ip,
+      root_block_device,
+      ebs_block_device,
+    ]
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,27 +1,115 @@
 locals {
-  this_id                           = "${compact(concat(coalescelist(aws_instance.this.*.id, aws_instance.this_t2.*.id), list("")))}"
-  this_availability_zone            = "${compact(concat(coalescelist(aws_instance.this.*.availability_zone, aws_instance.this_t2.*.availability_zone), list("")))}"
-  this_key_name                     = "${compact(concat(coalescelist(aws_instance.this.*.key_name, aws_instance.this_t2.*.key_name), list("")))}"
-  this_public_dns                   = "${compact(concat(coalescelist(aws_instance.this.*.public_dns, aws_instance.this_t2.*.public_dns), list("")))}"
-  this_public_ip                    = "${compact(concat(coalescelist(aws_instance.this.*.public_ip, aws_instance.this_t2.*.public_ip), list("")))}"
-  this_primary_network_interface_id = "${compact(concat(coalescelist(aws_instance.this.*.primary_network_interface_id, aws_instance.this_t2.*.primary_network_interface_id), list("")))}"
-  this_private_dns                  = "${compact(concat(coalescelist(aws_instance.this.*.private_dns, aws_instance.this_t2.*.private_dns), list("")))}"
-  this_private_ip                   = "${compact(concat(coalescelist(aws_instance.this.*.private_ip, aws_instance.this_t2.*.private_ip), list("")))}"
-  this_security_groups              = "${compact(concat(coalescelist(flatten(aws_instance.this.*.security_groups), flatten(aws_instance.this_t2.*.security_groups)), list("")))}"
-  this_vpc_security_group_ids       = "${compact(concat(coalescelist(flatten(aws_instance.this.*.vpc_security_group_ids), flatten(aws_instance.this_t2.*.vpc_security_group_ids)), list("")))}"
-  this_subnet_id                    = "${compact(concat(coalescelist(aws_instance.this.*.subnet_id, aws_instance.this_t2.*.subnet_id), list("")))}"
-  this_credit_specification         = "${aws_instance.this_t2.*.credit_specification}"
-  this_tags                         = "${coalescelist(flatten(aws_instance.this.*.tags), flatten(aws_instance.this_t2.*.tags))}"
+  this_id = compact(
+    concat(
+      coalescelist(aws_instance.this.*.id, aws_instance.this_t2.*.id),
+      [""],
+    ),
+  )
+  this_availability_zone = compact(
+    concat(
+      coalescelist(
+        aws_instance.this.*.availability_zone,
+        aws_instance.this_t2.*.availability_zone,
+      ),
+      [""],
+    ),
+  )
+  this_key_name = compact(
+    concat(
+      coalescelist(
+        aws_instance.this.*.key_name,
+        aws_instance.this_t2.*.key_name,
+      ),
+      [""],
+    ),
+  )
+  this_public_dns = compact(
+    concat(
+      coalescelist(
+        aws_instance.this.*.public_dns,
+        aws_instance.this_t2.*.public_dns,
+      ),
+      [""],
+    ),
+  )
+  this_public_ip = compact(
+    concat(
+      coalescelist(
+        aws_instance.this.*.public_ip,
+        aws_instance.this_t2.*.public_ip,
+      ),
+      [""],
+    ),
+  )
+  this_primary_network_interface_id = compact(
+    concat(
+      coalescelist(
+        aws_instance.this.*.primary_network_interface_id,
+        aws_instance.this_t2.*.primary_network_interface_id,
+      ),
+      [""],
+    ),
+  )
+  this_private_dns = compact(
+    concat(
+      coalescelist(
+        aws_instance.this.*.private_dns,
+        aws_instance.this_t2.*.private_dns,
+      ),
+      [""],
+    ),
+  )
+  this_private_ip = compact(
+    concat(
+      coalescelist(
+        aws_instance.this.*.private_ip,
+        aws_instance.this_t2.*.private_ip,
+      ),
+      [""],
+    ),
+  )
+  this_security_groups = compact(
+    concat(
+      coalescelist(
+        flatten(aws_instance.this.*.security_groups),
+        flatten(aws_instance.this_t2.*.security_groups),
+      ),
+      [""],
+    ),
+  )
+  this_vpc_security_group_ids = compact(
+    concat(
+      coalescelist(
+        flatten(aws_instance.this.*.vpc_security_group_ids),
+        flatten(aws_instance.this_t2.*.vpc_security_group_ids),
+      ),
+      [""],
+    ),
+  )
+  this_subnet_id = compact(
+    concat(
+      coalescelist(
+        aws_instance.this.*.subnet_id,
+        aws_instance.this_t2.*.subnet_id,
+      ),
+      [""],
+    ),
+  )
+  this_credit_specification = aws_instance.this_t2.*.credit_specification
+  this_tags = coalescelist(
+    flatten(aws_instance.this.*.tags),
+    flatten(aws_instance.this_t2.*.tags),
+  )
 }
 
 output "id" {
   description = "List of IDs of instances"
-  value       = ["${local.this_id}"]
+  value       = [local.this_id]
 }
 
 output "availability_zone" {
   description = "List of availability zones of instances"
-  value       = ["${local.this_availability_zone}"]
+  value       = [local.this_availability_zone]
 }
 
 // GH issue: https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/issues/8
@@ -32,55 +120,56 @@ output "availability_zone" {
 
 output "key_name" {
   description = "List of key names of instances"
-  value       = ["${local.this_key_name}"]
+  value       = [local.this_key_name]
 }
 
 output "public_dns" {
   description = "List of public DNS names assigned to the instances. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC"
-  value       = ["${local.this_public_dns}"]
+  value       = [local.this_public_dns]
 }
 
 output "public_ip" {
   description = "List of public IP addresses assigned to the instances, if applicable"
-  value       = ["${local.this_public_ip}"]
+  value       = [local.this_public_ip]
 }
 
 output "primary_network_interface_id" {
   description = "List of IDs of the primary network interface of instances"
-  value       = ["${local.this_primary_network_interface_id}"]
+  value       = [local.this_primary_network_interface_id]
 }
 
 output "private_dns" {
   description = "List of private DNS names assigned to the instances. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC"
-  value       = ["${local.this_private_dns}"]
+  value       = [local.this_private_dns]
 }
 
 output "private_ip" {
   description = "List of private IP addresses assigned to the instances"
-  value       = ["${local.this_private_ip}"]
+  value       = [local.this_private_ip]
 }
 
 output "security_groups" {
   description = "List of associated security groups of instances"
-  value       = ["${local.this_security_groups}"]
+  value       = [local.this_security_groups]
 }
 
 output "vpc_security_group_ids" {
   description = "List of associated security groups of instances, if running in non-default VPC"
-  value       = ["${local.this_vpc_security_group_ids}"]
+  value       = [local.this_vpc_security_group_ids]
 }
 
 output "subnet_id" {
   description = "List of IDs of VPC subnets of instances"
-  value       = ["${local.this_subnet_id}"]
+  value       = [local.this_subnet_id]
 }
 
 output "credit_specification" {
   description = "List of credit specification of instances"
-  value       = ["${local.this_credit_specification}"]
+  value       = [local.this_credit_specification]
 }
 
 output "tags" {
   description = "List of tags of instances"
-  value       = ["${local.this_tags}"]
+  value       = [local.this_tags]
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "monitoring" {
 
 variable "vpc_security_group_ids" {
   description = "A list of security group IDs to associate with"
-  type        = "list"
+  type        = list(string)
 }
 
 variable "subnet_id" {
@@ -63,7 +63,7 @@ variable "subnet_id" {
 variable "subnet_ids" {
   description = "A list of VPC Subnet IDs to launch in"
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "associate_public_ip_address" {
@@ -140,3 +140,4 @@ variable "use_num_suffix" {
   description = "Always append numerical suffix to instance name, even if instance_count is 1"
   default     = "false"
 }
+


### PR DESCRIPTION
Terraform 0.12.0 introduces some big changes to HCL, including dynamic block
parameters. This commit runs the command `terraform 0.12upgrade` against the
code.

More details about upgrading can be found here
  -> https://www.terraform.io/upgrade-guides/0-12.html

This does make the code incompatible with version <0.12.0