### PR TITLE
Allow different initial index number in tag suffix and allow user to choose an output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ module "ec2_cluster" {
   vpc_security_group_ids = ["sg-12345678"]
   subnet_id              = "subnet-eddcdzz4"
 
+  use_num_suffix         = true
+
   tags = {
     Terraform = "true"
     Environment = "dev"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ data "aws_ami" "ubuntu-xenial" {
 | tags | A mapping of tags to assign to the resource | map | `<map>` | no |
 | tenancy | The tenancy of the instance (if the instance is running in a VPC). Available values: default, dedicated, host. | string | `"default"` | no |
 | use\_num\_suffix | Always append numerical suffix to instance name, even if instance_count is 1 | string | `"false"` | no |
+| num\_suffix\_format | Choose the format that will be displayed for the number in the suffix. Only used if use\_num\_suffix is true. | string | `"%s-%d"` | no |
+| start\_suffix\_index | Choose the value to start the suffix index count at.  Only used if use\_num\_suffix is true. | string | "1"` | no |
 | user\_data | The user data to provide when launching the instance | string | `""` | no |
 | volume\_tags | A mapping of tags to assign to the devices created by the instance at launch time | map | `<map>` | no |
 | vpc\_security\_group\_ids | A list of security group IDs to associate with | list | n/a | yes |

--- a/examples/volume-attachment/main.tf
+++ b/examples/volume-attachment/main.tf
@@ -61,6 +61,10 @@ module "ec2" {
   subnet_id                   = "${element(data.aws_subnet_ids.all.ids, 0)}"
   vpc_security_group_ids      = ["${module.security_group.this_security_group_id}"]
   associate_public_ip_address = true
+
+  use_num_suffix              = true
+  num_suffix_format           = "%s-%02d"   # Default is "%s-%d"
+  start_suffix_index          = 50          # Default is 1
 }
 
 resource "aws_volume_attachment" "this_ec2" {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "this" {
   placement_group                      = "${var.placement_group}"
   tenancy                              = "${var.tenancy}"
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format(var.num_suffix_format, var.name, count.index+var.start_suffix_index) : var.name), var.tags)}"
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
@@ -77,7 +77,7 @@ resource "aws_instance" "this_t2" {
     cpu_credits = "${var.cpu_credits}"
   }
 
-  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format("%s-%d", var.name, count.index+1) : var.name), var.tags)}"
+  tags = "${merge(map("Name", (var.instance_count > 1) || (var.use_num_suffix == "true") ? format(num_suffix_format, var.name, count.index+var.start_suffix_index) : var.name), var.tags)}"
 
   lifecycle {
     # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:

--- a/variables.tf
+++ b/variables.tf
@@ -140,3 +140,13 @@ variable "use_num_suffix" {
   description = "Always append numerical suffix to instance name, even if instance_count is 1"
   default     = "false"
 }
+
+variable "num_suffix_format" {
+  description = "Allow a different output format for the suffix"
+  default     = "%s-%d"
+}
+
+variable "start_suffix_index" {
+  description = "Value to start the suffix index on. Default is 1"
+  default     = 1
+}


### PR DESCRIPTION
I've added two new variables. 

- num_suffix_format which allows the user to choose the format that will be displayed for the number portion of the suffix. 
- start_suffix_index which allows the user to choose the value to start the suffix index count at. 

