### PR TITLE
Additional EBS volumes are re-attached when an instance is recreated

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ data "aws_ami" "ubuntu-xenial" {
 * `network_interface` can't be specified together with `associate_public_ip_address`, which makes `network_interface`
   not configurable using this module at the moment
 * Changes in `ebs_block_device` argument will be ignored. Use [aws_volume_attachment](https://www.terraform.io/docs/providers/aws/r/volume_attachment.html) resource to attach and detach volumes from AWS EC2 instances. See [this example](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/tree/master/examples/volume-attachment).
+* When using variable `attached_block_device` then you **MUST NOT** use `ebs_block_device` of the EC2 module. Terraform currently supports only either inline (i.e. as sub block of `aws_instance`) or separate creation and attachment of EBS volumes (see [note](https://www.terraform.io/docs/providers/aws/r/instance.html#block-devices))
 * One of `subnet_id` or `subnet_ids` is required. If both are provided, the value of `subnet_id` is prepended to the value of `subnet_ids`.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,20 @@
 locals {
-  is_t_instance_type = replace(var.instance_type, "/^t[23]{1}\\..*$/", "1") == "1" ? true : false
+  is_t_instance_type          = replace(var.instance_type, "/^t[23]{1}\\..*$/", "1") == "1" ? true : false
+  attached_block_device_count = length(var.attached_block_device)
+  attached_block_device_total = var.instance_count * local.attached_block_device_count
+  subnet_ids                  = distinct(compact(concat([var.subnet_id], var.subnet_ids)))
+}
+
+/*  =========================================================================
+    Using subnets to determine the az instead of using calculated
+    az information from aws_instance.
+    This is necessary in order to prevent that the attached EBS volumes
+    are destroyed when an EC2 instance is recreated.
+    ========================================================================= */
+data "aws_subnet" "this" {
+  count = length(local.subnet_ids)
+
+  id = local.subnet_ids[count.index]
 }
 
 ######
@@ -8,13 +23,10 @@ locals {
 resource "aws_instance" "this" {
   count = var.instance_count
 
-  ami           = var.ami
-  instance_type = var.instance_type
-  user_data     = var.user_data
-  subnet_id = element(
-    distinct(compact(concat([var.subnet_id], var.subnet_ids))),
-    count.index,
-  )
+  ami                    = var.ami
+  instance_type          = var.instance_type
+  user_data              = var.user_data
+  subnet_id              = local.subnet_ids[count.index % length(local.subnet_ids)]
   key_name               = var.key_name
   monitoring             = var.monitoring
   get_password_data      = var.get_password_data
@@ -42,7 +54,7 @@ resource "aws_instance" "this" {
     for_each = var.ebs_block_device
     content {
       delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", null)
-      device_name           = ebs_block_device.value.device_name
+      device_name           = lookup(ebs_block_device.value, "device_name", null)
       encrypted             = lookup(ebs_block_device.value, "encrypted", null)
       iops                  = lookup(ebs_block_device.value, "iops", null)
       snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
@@ -68,14 +80,14 @@ resource "aws_instance" "this" {
 
   tags = merge(
     {
-      "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s-%d", var.name, count.index + 1) : var.name
+      Name = var.instance_count > 1 || var.use_num_suffix ? format("%s-%d", var.name, count.index + 1) : var.name
     },
     var.tags,
   )
 
   volume_tags = merge(
     {
-      "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s-%d", var.name, count.index + 1) : var.name
+      Name = var.instance_count > 1 || var.use_num_suffix ? format("%s-%d", var.name, count.index + 1) : var.name
     },
     var.volume_tags,
   )
@@ -94,3 +106,58 @@ resource "aws_instance" "this" {
     ]
   }
 }
+
+# iterate first over the instances and then over the attached EBS volumes
+# => it is possible to increase and decrease the number of instances
+# => it is not possible do add/remove additional volumes for all instances
+resource "aws_ebs_volume" "this" {
+  count = local.attached_block_device_total
+
+  availability_zone = data.aws_subnet.this[
+    floor(count.index / local.attached_block_device_count) % length(local.subnet_ids)
+  ].availability_zone
+
+  encrypted = lookup(var.attached_block_device[
+    count.index % local.attached_block_device_count
+  ], "encrypted", null)
+
+  iops = lookup(var.attached_block_device[
+    count.index % local.attached_block_device_count
+  ], "iops", null)
+
+  kms_key_id = lookup(var.attached_block_device[
+    count.index % local.attached_block_device_count
+
+  ], "kms_key_id", null)
+
+  size = lookup(var.attached_block_device[
+    count.index % local.attached_block_device_count
+
+  ], "volume_size", null)
+  snapshot_id = lookup(var.attached_block_device[
+    count.index % local.attached_block_device_count
+
+  ], "snapshot_id", null)
+  type = lookup(var.attached_block_device[
+    count.index % local.attached_block_device_count
+  ], "volume_type", null)
+  tags = merge(
+    {
+      Name = var.instance_count > 1 || var.use_num_suffix ? format("%s-%d", var.name, floor(count.index / local.attached_block_device_count) + 1) : var.name
+    },
+    var.volume_tags,
+  )
+}
+
+resource "aws_volume_attachment" "this" {
+  count = local.attached_block_device_total
+
+  device_name = lookup(var.attached_block_device[
+    count.index % local.attached_block_device_count
+  ], "device_name", null)
+  instance_id = aws_instance.this[
+    floor(count.index / local.attached_block_device_count)
+  ].id
+  volume_id = aws_ebs_volume.this[count.index].id
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -150,8 +150,14 @@ variable "root_block_device" {
   default     = []
 }
 
+variable "attached_block_device" {
+  description = "Additional EBS block devices to attach after the instance creation. Either use this variable or ebs_block_device but not both"
+  type        = list(map(string))
+  default     = []
+}
+
 variable "ebs_block_device" {
-  description = "Additional EBS block devices to attach to the instance"
+  description = "Additional EBS block devices to attach to the instance. Either use this variable or attached_block_device but not both"
   type        = list(map(string))
   default     = []
 }


### PR DESCRIPTION
- support use case where #instances > #subnets
- add variable `attached_block_device` for configuring attached EBS volumes
- document conflict between inline and separate created EBS volumes
- inline `ebs_block_device`: use lookup for all attributes
- use Terraform 0.12 syntax everywhere

## Description
This PR solves #117 

For the implementation some design decisions have been required:
1. retrieving the correct AZ of an EBS volume. 
  The implementation uses the subnets to determine the AZ instead of using calculated az information from `aws_instance`. This is necessary in order to prevent that the attached EBS volumes are destroyed and recreated when an EC2 instance is recreated.
1. sequence of creating EBS volumes: there are two possible strategies:
    1. support adding / removing instances
    1. support adding / removing attached EBS volumes
I have decided to use the first solution because scaling the number of instances was more important for my use case. Adding additional attached EBS volumes might be possible when moving stuff in the statefile around (I did not test this)


