### PR TITLE
Instance count as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ data "aws_ami" "ubuntu-xenial" {
 | tags | List of tags of instances |
 | volume\_tags | List of tags of volumes of instances |
 | vpc\_security\_group\_ids | List of associated security groups of instances, if running in non-default VPC |
+| instance\_count | Number of instances to launch specified as argument to this module |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -96,3 +96,8 @@ output "volume_tags" {
   description = "List of tags of volumes of instances"
   value       = local.this_volume_tags
 }
+
+output "instance_count" {
+  description = "Number of instances to launch specified as argument to this module"
+  value       = var.instance_count
+}


### PR DESCRIPTION
# Description

I have added "instance count" as output. This can be useful in scenarios like for example planning the amount of route 53 records to create by using it in combination of the rest of outputs of the module. At the moment, all the rest of the outputs cannot be used as "count" value in any other place because Terraform cannot predict how many instances will be created.
