### PR TITLE
Add encrypted and kms_key_id arguments to the ebs_* and root_* block …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,9 @@ resource "aws_instance" "this" {
     for_each = var.root_block_device
     content {
       delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
+      encrypted             = lookup(root_block_device.value, "encrypted", null)
       iops                  = lookup(root_block_device.value, "iops", null)
+      kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
       volume_size           = lookup(root_block_device.value, "volume_size", null)
       volume_type           = lookup(root_block_device.value, "volume_type", null)
     }
@@ -45,6 +47,7 @@ resource "aws_instance" "this" {
       device_name           = ebs_block_device.value.device_name
       encrypted             = lookup(ebs_block_device.value, "encrypted", null)
       iops                  = lookup(ebs_block_device.value, "iops", null)
+      kms_key_id            = lookup(ebs_block_device.value, "kms_key_id", null)
       snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
       volume_size           = lookup(ebs_block_device.value, "volume_size", null)
       volume_type           = lookup(ebs_block_device.value, "volume_type", null)


### PR DESCRIPTION
…device configuration blocks

This commit resolves #6

# Description

As of version 2.23.0 of the aws provider the aws_instance resource now supports encrypted and kms_key_id as arguments to the root_block_device configuration block. Additionally, kms_key_id has been added as an argument to ebs_block_device configuration block as it already supported encrypted previously. This PR adds these arguments for use in this module.
