### PR TITLE
Track all changes (remove ignore_changes lifecycle)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,14 +86,4 @@ resource "aws_instance" "this" {
   credit_specification {
     cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
   }
-
-  lifecycle {
-    # Due to several known issues in Terraform AWS provider related to arguments of aws_instance:
-    # (eg, https://github.com/terraform-providers/terraform-provider-aws/issues/2036)
-    # we have to ignore changes in the following arguments
-    ignore_changes = [
-      root_block_device,
-      ebs_block_device,
-    ]
-  }
 }


### PR DESCRIPTION
Since version [v2.7.0](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/releases/v2.7.0) root and EBS volumes support all arguments (including encryption) we don't need to ignore changes in those arguments.