### PR TITLE
Adding IPv6 outputs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.16.0
+  rev: v1.19.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.2.3
+  rev: v2.3.0
   hooks:
     - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ data "aws_ami" "ubuntu-xenial" {
 | availability\_zone | List of availability zones of instances |
 | credit\_specification | List of credit specification of instances |
 | id | List of IDs of instances |
+| ipv6\_addresses | A list of assigned IPv6 addresses, if any. |
 | key\_name | List of key names of instances |
 | password\_data | List of Base-64 encoded encrypted password data for the instance |
 | placement\_group | List of placement groups of instances |

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,6 +15,7 @@ locals {
   this_tags                         = coalescelist(aws_instance.this.*.tags, [""])
   this_volume_tags                  = coalescelist(aws_instance.this.*.volume_tags, [""])
   this_password_data                = coalescelist(aws_instance.this.*.password_data, [""])
+  this_ipv6_addresses               = compact(coalescelist(aws_instance.this.*.ipv6_addresses, [""]))
 }
 
 output "id" {
@@ -95,4 +96,9 @@ output "tags" {
 output "volume_tags" {
   description = "List of tags of volumes of instances"
   value       = local.this_volume_tags
+}
+
+output "ipv6_addresses" {
+  description = "A list of assigned IPv6 addresses, if any."
+  value       = local.this_ipv6_addresses
 }


### PR DESCRIPTION
## Description
Adding the `ipv6_addresses` output available to `aws_instance` resources.

## Motivation and Context
Created because I want to create AAAA records for EC2 instances created by this module.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.