### PR TITLE
credit_specification triggers panic in aws provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,11 @@ resource "aws_instance" "this" {
     var.volume_tags,
   )
 
-  credit_specification {
-    cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
+  dynamic "credit_specification" {
+    for_each = local.is_t_instance_type ? [var.cpu_credits] : []
+ 
+    content {
+      cpu_credits = credit_specification.value
+    }
   }
 }


### PR DESCRIPTION
# Description
The aws provider panic's when give the credit_specification block and the attribute is unsupported for the instance type. I don't know how this will yet be resolved by the provider, so in the meantime setting the block to dynamic should let us avoid the panic.

This is a workaround for #128 and the related upstream provider provider, [terraform-aws-provider#10203](https://github.com/terraform-providers/terraform-provider-aws/issues/10203).
