### PR TITLE
Support lifecycle customizations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,4 +93,10 @@ resource "aws_instance" "this" {
   credit_specification {
     cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
   }
+
+  lifecycle {
+    create_before_destroy = var.create_before_destroy
+    prevent_destroy       = var.prevent_destroy
+    ignore_changes        = var.ignore_changes
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -187,3 +187,20 @@ variable "use_num_suffix" {
   default     = false
 }
 
+variable "create_before_destroy" {
+  description = "A new replacement object is created first, and then the prior object is destroyed only once the replacement is created."
+  type        = bool
+  default     = false
+}
+
+variable "prevent_destroy" {
+  description = "This meta-argument, when set to true, will cause Terraform to reject with an error any plan that would destroy the infrastructure object associated with the resource, as long as the argument remains present in the configuration."
+  type        = bool
+  default     = false
+}
+
+variable "ignore_changes" {
+  description = "Specifies resource attributes that Terraform should ignore when planning updates to the associated remote object. The arguments corresponding to the given attribute names are considered when planning a create operation, but are ignored when planning an update." # https://www.terraform.io/docs/configuration/resources.html#ignore_changes
+  type        = list
+  default     = list()
+}


### PR DESCRIPTION
https://www.terraform.io/docs/configuration/resources.html#lifecycle-lifecycle-customizations

My use case is always using the latest AMI available but not automatically replacing the instance
without manually tainting it.

I was hoping to support the lifecycle with a single variable but it doesn't seem syntactically possible
with HCL2 at this time. Instead I'm using one variable for each of the three possible lifecycle meta-arguments.

This feature was requested by my colleagues and the folks in issue #141 