### PR TITLE
T3a instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  is_t_instance_type = "${replace(var.instance_type, "/^t[23]{1}\\..*$/", "1") == "1" ? "1" : "0"}"
+  is_t_instance_type = "${replace(var.instance_type, "/^t(2|3|3a){1}\\..*$/", "1") == "1" ? "1" : "0"}"
 }
 
 ######


### PR DESCRIPTION
# Description
The check to establish if an instance type belongs to the t family doesn't work for the new t3a type, so I updated the regexp.
