### PR TITLE
support aws spot instance requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # AWS EC2 Instance Terraform module
 
 Terraform module which creates EC2 instance(s) on AWS.
@@ -87,7 +88,7 @@ data "aws_ami" "ubuntu-xenial" {
 
 ## Notes
 
-* `network_interface` can't be specified together with `vpc_security_group_ids`, `associate_public_ip_address`, `subnet_id`. See [basic example](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/tree/master/examples/basic) for details. 
+* `network_interface` can't be specified together with `vpc_security_group_ids`, `associate_public_ip_address`, `subnet_id`. See [basic example](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/tree/master/examples/basic) for details.
 * Changes in `ebs_block_device` argument will be ignored. Use [aws_volume_attachment](https://www.terraform.io/docs/providers/aws/r/volume_attachment.html) resource to attach and detach volumes from AWS EC2 instances. See [this example](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/tree/master/examples/volume-attachment).
 * One of `subnet_id` or `subnet_ids` is required. If both are provided, the value of `subnet_id` is prepended to the value of `subnet_ids`.
 
@@ -128,6 +129,16 @@ data "aws_ami" "ubuntu-xenial" {
 | user\_data\_base64 | Can be used instead of user_data to pass base64-encoded binary data directly. Use this instead of user_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption. | string | `"null"` | no |
 | volume\_tags | A mapping of tags to assign to the devices created by the instance at launch time | map(string) | `{}` | no |
 | vpc\_security\_group\_ids | A list of security group IDs to associate with | list(string) | `"null"` | no |
+| instance\_request\_type | The Instance Request Type must be on_demand OR spot | string | `"on_demand"` | no |
+| spot\_price | The maximum price to request on the spot market (Default: On-demand price) | string | `"null"` | no |
+| spot\_wait\_for\_fulfillment | If set, Terraform will wait for the Spot Request to be fulfilled, and will throw an error if the timeout of 10m is reached | bool | `true` | no |
+| spot\_type | If set to one-time, after the instance is terminated, the spot request will be closed | string | `"persistent"` | no |
+| spot\_timeouts | The timeouts block allows you to specify timeouts for certain actions | set(object({}) | `[]` | no |
+| spot\_valid\_from | The start date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ) | string | `"null"` | no |
+| spot\_valid\_until | The end date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance requests are placed or enabled to fulfill the request | string | `"null"` | no |
+| spot\_instance\_interruption\_behaviour | Indicates whether a Spot instance stops or terminates when it is interrupted | string | `"stop"` | no |
+| spot\_block\_duration\_minutes | he required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360). The duration period starts as soon as your Spot instance receives its instance ID. At the end of the duration period, Amazon EC2 marks the Spot instance for termination and provides a Spot instance termination notice, which gives the instance a two-minute warning before it terminates. Note that you can't specify an Availability Zone group or a launch group if you specify a duration | number | `"null"` | no |
+| spot\_launch\_group | A launch group is a group of spot instances that launch together and terminate together. If left empty instances are launched and terminated individually | string | `"null"` | no |
 
 ## Outputs
 
@@ -155,6 +166,8 @@ data "aws_ami" "ubuntu-xenial" {
 | tags | List of tags of instances |
 | volume\_tags | List of tags of volumes of instances |
 | vpc\_security\_group\_ids | List of associated security groups of instances, if running in non-default VPC |
+| spot\_bid\_status | The current bid status of the Spot Instance Request |
+| spot\_request\_state | The current request state of the Spot Instance Request |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "aws_instance" "this" {
-  count = var.instance_count
+  count = var.instance_request_type == "on_demand" ? var.instance_count : 0
 
   ami              = var.ami
   instance_type    = var.instance_type
@@ -89,6 +89,117 @@ resource "aws_instance" "this" {
     },
     var.volume_tags,
   )
+
+  credit_specification {
+    cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
+  }
+}
+
+resource "aws_spot_instance_request" "this" {
+  count = var.instance_request_type == "spot" ? var.instance_count : 0
+
+  # spot specific arguments
+  spot_price                      = var.spot_price
+  wait_for_fulfillment            = var.spot_wait_for_fulfillment
+  spot_type                       = var.spot_type
+  instance_interruption_behaviour = var.spot_instance_interruption_behaviour
+  block_duration_minutes          = var.spot_block_duration_minutes
+  valid_from                      = var.spot_valid_from
+  valid_until                     = var.spot_valid_until
+  launch_group                    = var.spot_launch_group
+  # aws instance specific arguments
+  ami              = var.ami
+  instance_type    = var.instance_type
+  user_data        = var.user_data
+  user_data_base64 = var.user_data_base64
+  subnet_id = length(var.network_interface) > 0 ? null : element(
+    distinct(compact(concat([var.subnet_id], var.subnet_ids))),
+    count.index,
+  )
+  key_name               = var.key_name
+  monitoring             = var.monitoring
+  get_password_data      = var.get_password_data
+  vpc_security_group_ids = var.vpc_security_group_ids
+  iam_instance_profile   = var.iam_instance_profile
+
+  associate_public_ip_address = var.associate_public_ip_address
+  private_ip                  = length(var.private_ips) > 0 ? element(var.private_ips, count.index) : var.private_ip
+  ipv6_address_count          = var.ipv6_address_count
+  ipv6_addresses              = var.ipv6_addresses
+
+  ebs_optimized = var.ebs_optimized
+
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+    content {
+      delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
+      encrypted             = lookup(root_block_device.value, "encrypted", null)
+      iops                  = lookup(root_block_device.value, "iops", null)
+      kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
+      volume_size           = lookup(root_block_device.value, "volume_size", null)
+      volume_type           = lookup(root_block_device.value, "volume_type", null)
+    }
+  }
+
+  dynamic "ebs_block_device" {
+    for_each = var.ebs_block_device
+    content {
+      delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", null)
+      device_name           = ebs_block_device.value.device_name
+      encrypted             = lookup(ebs_block_device.value, "encrypted", null)
+      iops                  = lookup(ebs_block_device.value, "iops", null)
+      kms_key_id            = lookup(ebs_block_device.value, "kms_key_id", null)
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
+      volume_size           = lookup(ebs_block_device.value, "volume_size", null)
+      volume_type           = lookup(ebs_block_device.value, "volume_type", null)
+    }
+  }
+
+  dynamic "ephemeral_block_device" {
+    for_each = var.ephemeral_block_device
+    content {
+      device_name  = ephemeral_block_device.value.device_name
+      no_device    = lookup(ephemeral_block_device.value, "no_device", null)
+      virtual_name = lookup(ephemeral_block_device.value, "virtual_name", null)
+    }
+  }
+
+  dynamic "network_interface" {
+    for_each = var.network_interface
+    content {
+      device_index          = network_interface.value.device_index
+      network_interface_id  = lookup(network_interface.value, "network_interface_id", null)
+      delete_on_termination = lookup(network_interface.value, "delete_on_termination", false)
+    }
+  }
+
+  source_dest_check                    = length(var.network_interface) > 0 ? null : var.source_dest_check
+  disable_api_termination              = var.disable_api_termination
+  instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
+  placement_group                      = var.placement_group
+  tenancy                              = var.tenancy
+
+  tags = merge(
+    {
+      "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s-%d", var.name, count.index + 1) : var.name
+    },
+    var.tags,
+  )
+
+  volume_tags = merge(
+    {
+      "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s-%d", var.name, count.index + 1) : var.name
+    },
+    var.volume_tags,
+  )
+
+  dynamic "timeouts" {
+    for_each = var.spot_timeouts
+    content {
+      create = timeouts.value["create"]
+      delete = timeouts.value["delete"]
+    }
+  }
 
   credit_specification {
     cpu_credits = local.is_t_instance_type ? var.cpu_credits : null

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,109 +1,119 @@
 output "id" {
   description = "List of IDs of instances"
-  value       = aws_instance.this.*.id
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.id : aws_spot_instance_request.this.*.spot_instance_id
 }
 
 output "arn" {
   description = "List of ARNs of instances"
-  value       = aws_instance.this.*.arn
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.arn : aws_spot_instance_request.this.*.arn
 }
 
 output "availability_zone" {
   description = "List of availability zones of instances"
-  value       = aws_instance.this.*.availability_zone
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.availability_zone : aws_spot_instance_request.this.*.availability_zone
 }
 
 output "placement_group" {
   description = "List of placement groups of instances"
-  value       = aws_instance.this.*.placement_group
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.placement_group : aws_spot_instance_request.this.*.placement_group
 }
 
 output "key_name" {
   description = "List of key names of instances"
-  value       = aws_instance.this.*.key_name
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.key_name : aws_spot_instance_request.this.*.key_name
 }
 
 output "password_data" {
   description = "List of Base-64 encoded encrypted password data for the instance"
-  value       = aws_instance.this.*.password_data
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.password_data : aws_spot_instance_request.this.*.password_data
 }
 
 output "public_dns" {
   description = "List of public DNS names assigned to the instances. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC"
-  value       = aws_instance.this.*.public_dns
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.public_dns : aws_spot_instance_request.this.*.public_dns
 }
 
 output "public_ip" {
   description = "List of public IP addresses assigned to the instances, if applicable"
-  value       = aws_instance.this.*.public_ip
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.public_ip : aws_spot_instance_request.this.*.public_ip
 }
 
 output "ipv6_addresses" {
   description = "List of assigned IPv6 addresses of instances"
-  value       = aws_instance.this.*.ipv6_addresses
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.ipv6_addresses : aws_spot_instance_request.this.*.ipv6_addresses
 }
 
 output "primary_network_interface_id" {
   description = "List of IDs of the primary network interface of instances"
-  value       = aws_instance.this.*.primary_network_interface_id
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.primary_network_interface_id : aws_spot_instance_request.this.*.primary_network_interface_id
 }
 
 output "private_dns" {
   description = "List of private DNS names assigned to the instances. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC"
-  value       = aws_instance.this.*.private_dns
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.private_dns : aws_spot_instance_request.this.*.private_dns
 }
 
 output "private_ip" {
   description = "List of private IP addresses assigned to the instances"
-  value       = aws_instance.this.*.private_ip
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.private_ip : aws_spot_instance_request.this.*.private_ip
 }
 
 output "security_groups" {
   description = "List of associated security groups of instances"
-  value       = aws_instance.this.*.security_groups
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.security_groups : aws_spot_instance_request.this.*.security_groups
 }
 
 output "vpc_security_group_ids" {
   description = "List of associated security groups of instances, if running in non-default VPC"
-  value       = aws_instance.this.*.vpc_security_group_ids
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.vpc_security_group_ids : aws_spot_instance_request.this.*.vpc_security_group_ids
 }
 
 output "subnet_id" {
   description = "List of IDs of VPC subnets of instances"
-  value       = aws_instance.this.*.subnet_id
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.subnet_id : aws_spot_instance_request.this.*.subnet_id
 }
 
 output "credit_specification" {
   description = "List of credit specification of instances"
-  value       = aws_instance.this.*.credit_specification
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.credit_specification : aws_spot_instance_request.this.*.credit_specification
 }
 
 output "instance_state" {
   description = "List of instance states of instances"
-  value       = aws_instance.this.*.instance_state
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.instance_state : aws_spot_instance_request.this.*.instance_state
 }
 
 output "root_block_device_volume_ids" {
   description = "List of volume IDs of root block devices of instances"
-  value       = [for device in aws_instance.this.*.root_block_device : device.*.volume_id]
+  value       = var.instance_request_type == "on_demand" ? [for device in aws_instance.this.*.root_block_device : device.*.volume_id] : [for device in aws_spot_instance_request.this.*.root_block_device : device.*.volume_id]
 }
 
 output "ebs_block_device_volume_ids" {
   description = "List of volume IDs of EBS block devices of instances"
-  value       = [for device in aws_instance.this.*.ebs_block_device : device.*.volume_id]
+  value       = var.instance_request_type == "on_demand" ? [for device in aws_instance.this.*.ebs_block_device : device.*.volume_id] : [for device in aws_spot_instance_request.this.*.ebs_block_device : device.*.volume_id]
 }
 
 output "tags" {
   description = "List of tags of instances"
-  value       = aws_instance.this.*.tags
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.tags : aws_spot_instance_request.this.*.tags
 }
 
 output "volume_tags" {
   description = "List of tags of volumes of instances"
-  value       = aws_instance.this.*.volume_tags
+  value       = var.instance_request_type == "on_demand" ? aws_instance.this.*.volume_tags : aws_spot_instance_request.this.*.volume_tags
 }
 
 output "instance_count" {
   description = "Number of instances to launch specified as argument to this module"
   value       = var.instance_count
+}
+
+output "spot_bid_status" {
+  description = "The current bid status of the Spot Instance Request"
+  value       = aws_spot_instance_request.this.*.spot_bid_status
+}
+
+output "spot_request_state" {
+  description = "The current request state of the Spot Instance Request"
+  value       = aws_spot_instance_request.this.*.spot_request_state
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "instance_request_type" {
+  description = "The Instance Request Type must be on_demand OR spot"
+  type        = string
+  default     = "on_demand"
+}
+
 variable "name" {
   description = "Name to be used on all resources as prefix"
   type        = string
@@ -187,3 +193,61 @@ variable "use_num_suffix" {
   default     = false
 }
 
+variable "spot_price" {
+  description = "The maximum price to request on the spot market (Default: On-demand price)"
+  type        = string
+  default     = null
+}
+
+variable "spot_wait_for_fulfillment" {
+  description = "If set, Terraform will wait for the Spot Request to be fulfilled, and will throw an error if the timeout of 10m is reached"
+  type        = bool
+  default     = true
+}
+
+variable "spot_type" {
+  description = "If set to one-time, after the instance is terminated, the spot request will be closed"
+  type        = string
+  default     = "persistent"
+}
+
+variable "spot_timeouts" {
+  description = "The timeouts block allows you to specify timeouts for certain actions"
+  type = set(object(
+    {
+      create = string
+      delete = string
+    }
+  ))
+  default = []
+}
+
+variable "spot_valid_from" {
+  description = "The start date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ)"
+  type        = string
+  default     = null
+}
+
+variable "spot_valid_until" {
+  description = "The end date and time of the request, in UTC RFC3339 format(for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance requests are placed or enabled to fulfill the request"
+  type        = string
+  default     = null
+}
+
+variable "spot_instance_interruption_behaviour" {
+  description = "Indicates whether a Spot instance stops or terminates when it is interrupted"
+  type        = string
+  default     = "stop"
+}
+
+variable "spot_block_duration_minutes" {
+  description = "The required duration for the Spot instances, in minutes. This value must be a multiple of 60 (60, 120, 180, 240, 300, or 360). The duration period starts as soon as your Spot instance receives its instance ID. At the end of the duration period, Amazon EC2 marks the Spot instance for termination and provides a Spot instance termination notice, which gives the instance a two-minute warning before it terminates. Note that you can't specify an Availability Zone group or a launch group if you specify a duration"
+  type        = number
+  default     = null
+}
+
+variable "spot_launch_group" {
+  description = "A launch group is a group of spot instances that launch together and terminate together. If left empty instances are launched and terminated individually"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Description
closes https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/issues/158

## Motivation and Context
This change updates the module to support aws_spot_instance_request which inherits all the arguments for aws_instance resource

## Breaking Changes
None, this is backwards compatible

## How Has This Been Tested?

1. Tested backwards compatibility with an existing aws_instance resource
2. Tested spot instance_request_type
3. Tested various spot variables


