### PR TITLE
added volume tag ignore to stop ebs volume (attached) tags being clob…

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,3 +1,7 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
 {{ if .Versions -}}
 <a name="unreleased"></a>
 ## [Unreleased]
@@ -5,12 +9,40 @@
 {{ range .Unreleased.CommitGroups -}}
 ### {{ .Title }}
 {{ range .Commits -}}
+{{/* SKIPPING RULES - START */ -}}
+{{- if not (hasPrefix .Subject "Updated CHANGELOG") -}}
+{{- if not (contains .Subject "[ci skip]") -}}
+{{- if not (contains .Subject "[skip ci]") -}}
+{{- if not (hasPrefix .Subject "Merge pull request ") -}}
+{{- if not (hasPrefix .Subject "Added CHANGELOG") -}}
+{{- /* SKIPPING RULES - END */ -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{/* SKIPPING RULES - START */ -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{/* SKIPPING RULES - END */ -}}
 {{ end }}
 {{ end -}}
 {{ else }}
 {{ range .Unreleased.Commits -}}
+{{/* SKIPPING RULES - START */ -}}
+{{- if not (hasPrefix .Subject "Updated CHANGELOG") -}}
+{{- if not (contains .Subject "[ci skip]") -}}
+{{- if not (contains .Subject "[skip ci]") -}}
+{{- if not (hasPrefix .Subject "Merge pull request ") -}}
+{{- if not (hasPrefix .Subject "Added CHANGELOG") -}}
+{{- /* SKIPPING RULES - END */ -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{/* SKIPPING RULES - START */ -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{/* SKIPPING RULES - END */ -}}
 {{ end }}
 {{ end -}}
 {{ end -}}
@@ -22,12 +54,40 @@
 {{ range .CommitGroups -}}
 ### {{ .Title }}
 {{ range .Commits -}}
+{{/* SKIPPING RULES - START */ -}}
+{{- if not (hasPrefix .Subject "Updated CHANGELOG") -}}
+{{- if not (contains .Subject "[ci skip]") -}}
+{{- if not (contains .Subject "[skip ci]") -}}
+{{- if not (hasPrefix .Subject "Merge pull request ") -}}
+{{- if not (hasPrefix .Subject "Added CHANGELOG") -}}
+{{- /* SKIPPING RULES - END */ -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{/* SKIPPING RULES - START */ -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{/* SKIPPING RULES - END */ -}}
 {{ end }}
 {{ end -}}
 {{ else }}
 {{ range .Commits -}}
+{{/* SKIPPING RULES - START */ -}}
+{{- if not (hasPrefix .Subject "Updated CHANGELOG") -}}
+{{- if not (contains .Subject "[ci skip]") -}}
+{{- if not (contains .Subject "[skip ci]") -}}
+{{- if not (hasPrefix .Subject "Merge pull request ") -}}
+{{- if not (hasPrefix .Subject "Added CHANGELOG") -}}
+{{- /* SKIPPING RULES - END */ -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{/* SKIPPING RULES - START */ -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{/* SKIPPING RULES - END */ -}}
 {{ end }}
 {{ end -}}
 

--- a/main.tf
+++ b/main.tf
@@ -93,4 +93,10 @@ resource "aws_instance" "this" {
   credit_specification {
     cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
   }
+
+  lifecycle {
+    ignore_changes = [
+      volume_tags,
+    ]
+  }
 }


### PR DESCRIPTION
## Description
Added code to stop the volume_tags flip flopping when tags are created on attached ebs volumes.
addressing issue #164 (filed by myself).

## Motivation and Context
When ebs volumes are attached to an instance generated with this module on subsequent applies terraform will flip-flop the volume tags between those on the instance and those on ebs volumes.

this is an open bug in terraform here:

 https://github.com/terraform-providers/terraform-provider-aws/issues/770

## Breaking Changes
pretty sure it breaks nothing.

## How Has This Been Tested?
used in own code on branch, tags are left alone and no longer flip flop, volume tags applied to created volumes and ebs volumes that are attached (not created by the instance) keep their original tags.
