### PR TITLE
fix: lifecycle changes for bug 164

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,4 +93,10 @@ resource "aws_instance" "this" {
   credit_specification {
     cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
   }
+
+  lifecycle {
+    ignore_changes = [
+      volume_tags,
+    ]
+  }
 }


### PR DESCRIPTION
## Description
Stops the clobbering of volume tags if you have EBS volumes attached with their own tags

## Motivation and Context
Fixes a bug triggered by an outstanding terraform issue:
https://github.com/terraform-providers/terraform-provider-aws/issues/770

<!--- If it fixes an open issue, please link to the issue here. -->
closes #164
## Breaking Changes
None 

## How Has This Been Tested?

Ran in live code from my repository, tags no longer flip-flopped between instance tags and EBS volume tags, resources kept their own tags.

