### PR TITLE
Issue/168

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ No requirements.
 |------|-------------|------|---------|:--------:|
 | ami | ID of AMI to use for the instance | `string` | n/a | yes |
 | associate\_public\_ip\_address | If true, the EC2 instance will have associated public IP address | `bool` | `null` | no |
+| cpu\_core\_count | Sets the number of CPU cores for an instance. | `number` | `null` | no |
 | cpu\_credits | The credit option for CPU usage (unlimited or standard) | `string` | `"standard"` | no |
+| cpu\_threads\_per\_core | Sets the number of CPU threads per core for an instance (has no effect unless cpu\_core\_count is also set). | `number` | `2` | no |
 | disable\_api\_termination | If true, enables EC2 Instance Termination Protection | `bool` | `false` | no |
 | ebs\_block\_device | Additional EBS block devices to attach to the instance | `list(map(string))` | `[]` | no |
 | ebs\_optimized | If true, the launched EC2 instance will be EBS-optimized | `bool` | `false` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -173,3 +173,35 @@ module "ec2_zero" {
   subnet_id              = tolist(data.aws_subnet_ids.all.ids)[0]
   vpc_security_group_ids = [module.security_group.this_security_group_id]
 }
+
+module "ec2_optimize_cpu" {
+  source = "../../"
+
+  instance_count = 1
+
+  name          = "example-optimize-cpu"
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "c4.2xlarge"
+  subnet_id     = tolist(data.aws_subnet_ids.all.ids)[0]
+
+  vpc_security_group_ids      = [module.security_group.this_security_group_id]
+  associate_public_ip_address = true
+  placement_group             = aws_placement_group.web.id
+
+  user_data_base64 = base64encode(local.user_data)
+
+  root_block_device = [
+    {
+      volume_type = "gp2"
+      volume_size = 10
+    },
+  ]
+  cpu_core_count       = 2 # default 4
+  cpu_threads_per_core = 1 # default 2
+
+
+  tags = {
+    "Env"      = "Private"
+    "Location" = "Secret"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,8 @@ resource "aws_instance" "this" {
   instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
   placement_group                      = var.placement_group
   tenancy                              = var.tenancy
+  cpu_core_count                       = var.cpu_core_count
+  cpu_threads_per_core                 = var.cpu_threads_per_core
 
   tags = merge(
     {

--- a/variables.tf
+++ b/variables.tf
@@ -193,4 +193,14 @@ variable "num_suffix_format" {
   default     = "-%d"
 }
 
+variable "cpu_core_count" {
+  description = "Sets the number of CPU cores for an instance." # This option is only supported on creation of instance type that support CPU Options https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html#cpu-options-supported-instances-values
+  type        = number
+  default     = null
+}
 
+variable "cpu_threads_per_core" {
+  description = "Sets the number of CPU threads per core for an instance (has no effect unless cpu_core_count is also set)."
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
## Description
Added `cpu_core_count` & `cpu_threads_per_core` options for the `aws_instance` resource.

## Motivation and Context
This allows to create cpu optimized instances. Also covers one of the use cases which was missing from the module.
Fixes #168 . 

## Breaking Changes
N/A

## How Has This Been Tested?
Tried to create an ec2 instance with a basic example (also added in the examples/basic).
