### PR TITLE
Support for EC2 metadata_options as map

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ No requirements.
 | ipv6\_addresses | Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `null` | no |
 | key\_name | The key name to use for the instance | `string` | `""` | no |
 | monitoring | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
+| metadata_options | Map of values for metadata_options (IMDSv2 related) | `map` | `[]` | no |
 | name | Name to be used on all resources as prefix | `string` | n/a | yes |
 | network\_interface | Customize network interfaces to be attached at instance boot time | `list(map(string))` | `[]` | no |
 | num\_suffix\_format | Numerical suffix format used as the volume and EC2 instance name suffix | `string` | `"-%d"` | no |

--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,15 @@ resource "aws_instance" "this" {
   placement_group                      = var.placement_group
   tenancy                              = var.tenancy
 
+
+  metadata_options {
+
+          http_endpoint = lookup(var.metadata_options, "http_endpoint" , "enabled")
+          http_tokens = lookup(var.metadata_options, "http_tokens" , "optional" )
+          http_put_response_hop_limit = lookup(var.metadata_options, "http_put_response_hop_limit" , 1 )
+    
+  }
+
   tags = merge(
     {
       "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s${var.num_suffix_format}", var.name, count.index + 1) : var.name

--- a/variables.tf
+++ b/variables.tf
@@ -193,4 +193,8 @@ variable "num_suffix_format" {
   default     = "-%d"
 }
 
-
+variable "metadata_options" {
+  description = "Map of values for metadata_options (IMDSv2 related)"
+  type = map(string)
+  default = {}
+}


### PR DESCRIPTION
## Description
Support for metadata_options block. Required for IMDSv2 implementation and AWS Security guidelines. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In new AWS Security guidelineas, IMDSv2 (http_tokens) is required to be enabled in all instances.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No AFAIK
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Executed in our environment, attached TF plan and apply.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
----------
included in ec2.tf
```terraform
  metadata_options = {
      http_tokens = "required"
    }
```
plan:
```terraform
      ~ metadata_options {
            http_endpoint               = "enabled"
            http_put_response_hop_limit = 1
          ~ http_tokens                 = "optional" -> "required"
        }
```
applied with no error.