### PR TITLE
fix: associate_public_ip_address setting behavior based on whether network_interface is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-
+- Fix associate_public_ip_address setting behavior based on whether network_interface is specified ([#188](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/issues/188))
 
 <a name="v2.15.0"></a>
 ## [v2.15.0] - 2020-06-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Fix associate_public_ip_address setting behavior based on whether network_interface is specified ([#188](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/issues/188))
+- fix: associate_public_ip_address setting behavior based on whether network_interface is specified ([#188](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/issues/188))
 
 <a name="v2.15.0"></a>
 ## [v2.15.0] - 2020-06-10

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_instance" "this" {
   vpc_security_group_ids = var.vpc_security_group_ids
   iam_instance_profile   = var.iam_instance_profile
 
-  associate_public_ip_address = var.associate_public_ip_address
+  associate_public_ip_address = length(var.network_interface) > 0 ? null : var.associate_public_ip_address
   private_ip                  = length(var.private_ips) > 0 ? element(var.private_ips, count.index) : var.private_ip
   ipv6_address_count          = var.ipv6_address_count
   ipv6_addresses              = var.ipv6_addresses


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `associate_public_ip_address` setting conflicts with the `network_interface` setting. Therefore if `network_interface` is specified then `associate_public_ip_address` is set to `null`. This is the same behavior modeled after the `source_dest_check` setting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#188 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
