### PR TITLE
Provide a toggle to disable the volume_tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "aws_instance" "this" {
-  count = var.instance_count
+  count = !var.lifecycle_ignore_volume_tags ? var.instance_count : 0
 
   ami              = var.ami
   instance_type    = var.instance_type
@@ -101,5 +101,110 @@ resource "aws_instance" "this" {
 
   credit_specification {
     cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
+  }
+}
+resource "aws_instance" "this-ignoring-volume-tags" {
+  count = var.lifecycle_ignore_volume_tags ? var.instance_count : 0
+
+  ami              = var.ami
+  instance_type    = var.instance_type
+  user_data        = var.user_data
+  user_data_base64 = var.user_data_base64
+  subnet_id = length(var.network_interface) > 0 ? null : element(
+    distinct(compact(concat([var.subnet_id], var.subnet_ids))),
+    count.index,
+  )
+  key_name               = var.key_name
+  monitoring             = var.monitoring
+  get_password_data      = var.get_password_data
+  vpc_security_group_ids = var.vpc_security_group_ids
+  iam_instance_profile   = var.iam_instance_profile
+
+  associate_public_ip_address = var.associate_public_ip_address
+  private_ip                  = length(var.private_ips) > 0 ? element(var.private_ips, count.index) : var.private_ip
+  ipv6_address_count          = var.ipv6_address_count
+  ipv6_addresses              = var.ipv6_addresses
+
+  ebs_optimized = var.ebs_optimized
+
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+    content {
+      delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
+      encrypted             = lookup(root_block_device.value, "encrypted", null)
+      iops                  = lookup(root_block_device.value, "iops", null)
+      kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
+      volume_size           = lookup(root_block_device.value, "volume_size", null)
+      volume_type           = lookup(root_block_device.value, "volume_type", null)
+    }
+  }
+
+  dynamic "ebs_block_device" {
+    for_each = var.ebs_block_device
+    content {
+      delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", null)
+      device_name           = ebs_block_device.value.device_name
+      encrypted             = lookup(ebs_block_device.value, "encrypted", null)
+      iops                  = lookup(ebs_block_device.value, "iops", null)
+      kms_key_id            = lookup(ebs_block_device.value, "kms_key_id", null)
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
+      volume_size           = lookup(ebs_block_device.value, "volume_size", null)
+      volume_type           = lookup(ebs_block_device.value, "volume_type", null)
+    }
+  }
+
+  dynamic "ephemeral_block_device" {
+    for_each = var.ephemeral_block_device
+    content {
+      device_name  = ephemeral_block_device.value.device_name
+      no_device    = lookup(ephemeral_block_device.value, "no_device", null)
+      virtual_name = lookup(ephemeral_block_device.value, "virtual_name", null)
+    }
+  }
+
+  dynamic "metadata_options" {
+    for_each = length(keys(var.metadata_options)) == 0 ? [] : [var.metadata_options]
+    content {
+      http_endpoint               = lookup(metadata_options.value, "http_endpoint", "enabled")
+      http_tokens                 = lookup(metadata_options.value, "http_tokens", "optional")
+      http_put_response_hop_limit = lookup(metadata_options.value, "http_put_response_hop_limit", "1")
+    }
+  }
+
+  dynamic "network_interface" {
+    for_each = var.network_interface
+    content {
+      device_index          = network_interface.value.device_index
+      network_interface_id  = lookup(network_interface.value, "network_interface_id", null)
+      delete_on_termination = lookup(network_interface.value, "delete_on_termination", false)
+    }
+  }
+
+  source_dest_check                    = length(var.network_interface) > 0 ? null : var.source_dest_check
+  disable_api_termination              = var.disable_api_termination
+  instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
+  placement_group                      = var.placement_group
+  tenancy                              = var.tenancy
+
+  tags = merge(
+    {
+      "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s${var.num_suffix_format}", var.name, count.index + 1) : var.name
+    },
+    var.tags,
+  )
+
+  volume_tags = merge(
+    {
+      "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s${var.num_suffix_format}", var.name, count.index + 1) : var.name
+    },
+    var.volume_tags,
+  )
+
+  credit_specification {
+    cpu_credits = local.is_t_instance_type ? var.cpu_credits : null
+  }
+
+  lifecycle {
+    ignore_changes = [volume_tags]
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,111 +1,111 @@
 output "id" {
   description = "List of IDs of instances"
-  value       = aws_instance.this.*.id
+  value       = concat(aws_instance.this.*.id, aws_instance.this-ignoring-volume-tags.*.id)
 }
 
 output "arn" {
   description = "List of ARNs of instances"
-  value       = aws_instance.this.*.arn
+  value       = concat(aws_instance.this.*.arn, aws_instance.this-ignoring-volume-tags.*.arn)
 }
 
 output "availability_zone" {
   description = "List of availability zones of instances"
-  value       = aws_instance.this.*.availability_zone
+  value       = concat(aws_instance.this.*.availability_zone, aws_instance.this-ignoring-volume-tags.*.availability_zone)
 }
 
 output "placement_group" {
   description = "List of placement groups of instances"
-  value       = aws_instance.this.*.placement_group
+  value       = concat(aws_instance.this.*.placement_group, aws_instance.this-ignoring-volume-tags.*.placement_group)
 }
 
 output "key_name" {
   description = "List of key names of instances"
-  value       = aws_instance.this.*.key_name
+  value       = concat(aws_instance.this.*.key_name, aws_instance.this-ignoring-volume-tags.*.key_name)
 }
 
 output "password_data" {
   description = "List of Base-64 encoded encrypted password data for the instance"
-  value       = aws_instance.this.*.password_data
+  value       = concat(aws_instance.this.*.password_data, aws_instance.this-ignoring-volume-tags.*.password_data)
 }
 
 output "public_dns" {
   description = "List of public DNS names assigned to the instances. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC"
-  value       = aws_instance.this.*.public_dns
+  value       = concat(aws_instance.this.*.public_dns, aws_instance.this-ignoring-volume-tags.*.public_dns)
 }
 
 output "public_ip" {
   description = "List of public IP addresses assigned to the instances, if applicable"
-  value       = aws_instance.this.*.public_ip
+  value       = concat(aws_instance.this.*.public_ip, aws_instance.this-ignoring-volume-tags.*.public_ip)
 }
 
 output "ipv6_addresses" {
   description = "List of assigned IPv6 addresses of instances"
-  value       = aws_instance.this.*.ipv6_addresses
+  value       = concat(aws_instance.this.*.ipv6_addresses, aws_instance.this-ignoring-volume-tags.*.ipv6_addresses)
 }
 
 output "primary_network_interface_id" {
   description = "List of IDs of the primary network interface of instances"
-  value       = aws_instance.this.*.primary_network_interface_id
+  value       = concat(aws_instance.this.*.primary_network_interface_id, aws_instance.this-ignoring-volume-tags.*.primary_network_interface_id)
 }
 
 output "private_dns" {
   description = "List of private DNS names assigned to the instances. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC"
-  value       = aws_instance.this.*.private_dns
+  value       = concat(aws_instance.this.*.private_dns, aws_instance.this-ignoring-volume-tags.*.private_dns)
 }
 
 output "private_ip" {
   description = "List of private IP addresses assigned to the instances"
-  value       = aws_instance.this.*.private_ip
+  value       = concat(aws_instance.this.*.private_ip, aws_instance.this-ignoring-volume-tags.*.private_ip)
 }
 
 output "security_groups" {
   description = "List of associated security groups of instances"
-  value       = aws_instance.this.*.security_groups
+  value       = concat(aws_instance.this.*.security_groups, aws_instance.this-ignoring-volume-tags.*.security_groups)
 }
 
 output "vpc_security_group_ids" {
   description = "List of associated security groups of instances, if running in non-default VPC"
-  value       = aws_instance.this.*.vpc_security_group_ids
+  value       = concat(aws_instance.this.*.vpc_security_group_ids, aws_instance.this-ignoring-volume-tags.*.vpc_security_group_ids)
 }
 
 output "subnet_id" {
   description = "List of IDs of VPC subnets of instances"
-  value       = aws_instance.this.*.subnet_id
+  value       = concat(aws_instance.this.*.subnet_id, aws_instance.this-ignoring-volume-tags.*.subnet_id)
 }
 
 output "credit_specification" {
   description = "List of credit specification of instances"
-  value       = aws_instance.this.*.credit_specification
+  value       = concat(aws_instance.this.*.credit_specification, aws_instance.this-ignoring-volume-tags.*.credit_specification)
 }
 
 output "metadata_options" {
   description = "List of metadata options of instances"
-  value       = aws_instance.this.*.metadata_options
+  value       = concat(aws_instance.this.*.metadata_options, aws_instance.this-ignoring-volume-tags.*.metadata_options)
 }
 
 output "instance_state" {
   description = "List of instance states of instances"
-  value       = aws_instance.this.*.instance_state
+  value       = concat(aws_instance.this.*.instance_state, aws_instance.this-ignoring-volume-tags.*.instance_state)
 }
 
 output "root_block_device_volume_ids" {
   description = "List of volume IDs of root block devices of instances"
-  value       = [for device in aws_instance.this.*.root_block_device : device.*.volume_id]
+  value       = [for device in concat(aws_instance.this.*.root_block_device, aws_instance.this-ignoring-volume-tags.*.root_block_device) : device.*.volume_id]
 }
 
 output "ebs_block_device_volume_ids" {
   description = "List of volume IDs of EBS block devices of instances"
-  value       = [for device in aws_instance.this.*.ebs_block_device : device.*.volume_id]
+  value       = [for device in concat(aws_instance.this.*.ebs_block_device, aws_instance.this-ignoring-volume-tags.*.ebs_block_device) : device.*.volume_id]
 }
 
 output "tags" {
   description = "List of tags of instances"
-  value       = aws_instance.this.*.tags
+  value       = concat(aws_instance.this.*.tags, aws_instance.this-ignoring-volume-tags.*.tags)
 }
 
 output "volume_tags" {
   description = "List of tags of volumes of instances"
-  value       = aws_instance.this.*.volume_tags
+  value       = concat(aws_instance.this.*.volume_tags, aws_instance.this-ignoring-volume-tags.*.volume_tags)
 }
 
 output "instance_count" {

--- a/variables.tf
+++ b/variables.tf
@@ -151,6 +151,12 @@ variable "volume_tags" {
   default     = {}
 }
 
+variable "lifecycle_ignore_volume_tags" {
+  description = "When set, the aws_instance is created and further volume_tag changes are ignored. Note: toggling this flag on existing resource is destructive."
+  type    = bool
+  default = false
+}
+
 variable "root_block_device" {
   description = "Customize details about the root block device of the instance. See Block Devices below for details"
   type        = list(map(string))
@@ -198,3 +204,5 @@ variable "num_suffix_format" {
   type        = string
   default     = "-%d"
 }
+
+


### PR DESCRIPTION
## Description

Note, while this works it's a pretty clunky solution. I'm putting this out there as _an option_.

Currently using this module while _also_ adding a ebs_volume_attachment causes apply churn as the aws_instance's volume_tags conflict with additional tags added outside of the module.

This change introduces a new internal resource that has the `lifecycle ignore_changes` property set to ignore `volume_tags`. While clunky, this was the only way to address the volume tag churn.

Perhaps in the future it can be removed if the upstream is able to define a sane way of managing these conflicting entries.

## Motivation and Context
Since lifecycle is a dynamic property, we have to create a separate
resource that has this feature disabled. It's not the most graceful
workaround, but it works well enough.

## Breaking Changes

The default will keep the current behavior unchanged. Any users who
desire to enable this on existing resources would need to perform a
`state mv` to avoid replacing resources.

## How Has This Been Tested?

I applied the changes on an existing host to verify the move is without issue. I applied by also tainting and re-running.

## Related

- #164
