### PR TITLE
Move volume_tags into dynamic blocks's tags parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,12 @@ resource "aws_instance" "this" {
       kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
       volume_size           = lookup(root_block_device.value, "volume_size", null)
       volume_type           = lookup(root_block_device.value, "volume_type", null)
+      tags = merge(
+        {
+          "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s${var.num_suffix_format}", var.name, count.index + 1) : var.name
+        },
+        var.volume_tags,
+      )
     }
   }
 
@@ -49,6 +55,12 @@ resource "aws_instance" "this" {
       snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
       volume_size           = lookup(ebs_block_device.value, "volume_size", null)
       volume_type           = lookup(ebs_block_device.value, "volume_type", null)
+      tags = merge(
+        {
+          "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s${var.num_suffix_format}", var.name, count.index + 1) : var.name
+        },
+        var.volume_tags,
+      )
     }
   }
 
@@ -90,13 +102,6 @@ resource "aws_instance" "this" {
       "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s${var.num_suffix_format}", var.name, count.index + 1) : var.name
     },
     var.tags,
-  )
-
-  volume_tags = merge(
-    {
-      "Name" = var.instance_count > 1 || var.use_num_suffix ? format("%s${var.num_suffix_format}", var.name, count.index + 1) : var.name
-    },
-    var.volume_tags,
   )
 
   credit_specification {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 2.65"
+    aws = ">= 3.24.0"
   }
 }


### PR DESCRIPTION
## Description
This effectively removes the churning that is happening when an
ebs_volume is attached separately from the module

Takes advantage of the new feature in the aws provider available as of 3.24.0.
https://github.com/hashicorp/terraform-provider-aws/pull/15474

## Motivation and Context
When using this module and creating aws_ebs_volumes/aws_ebs_volume_attachments outside of the module causes constant apply churn because the tags conflict.

## Breaking Changes
Tags on the ebs_block_volumes may change
Requires 3.24.0 of aws provider, since this is a major version requirement change in the module

## How Has This Been Tested?

I took existing instances with externally defined ebs_volumes and upgraded to this module. I also created resources anew.

Note: I'm still doing a bit more testing to validate, I did notice some initial churn (had to apply twice). But even this is a major behavior improvement.