### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.44.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,6 +21,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ data "aws_ami" "ubuntu-xenial" {
 |------|---------|
 | aws | >= 2.65 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/resources/instance) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -171,7 +181,6 @@ data "aws_ami" "ubuntu-xenial" {
 | tags | List of tags of instances |
 | volume\_tags | List of tags of volumes of instances |
 | vpc\_security\_group\_ids | List of associated security groups of instances, if running in non-default VPC |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -28,6 +28,30 @@ Note that this example may create resources which can cost money. Run `terraform
 |------|---------|
 | aws | >= 2.65 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| ec2 | ../../ |  |
+| ec2_with_metadata_options | ../../ |  |
+| ec2_with_network_interface | ../../ |  |
+| ec2_with_t2_unlimited | ../../ |  |
+| ec2_with_t3_unlimited | ../../ |  |
+| ec2_zero | ../../ |  |
+| security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/data-sources/ami) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/resources/eip) |
+| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/resources/kms_key) |
+| [aws_network_interface](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/resources/network_interface) |
+| [aws_placement_group](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/resources/placement_group) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/data-sources/vpc) |
+
 ## Inputs
 
 No input.
@@ -51,5 +75,4 @@ No input.
 | t2\_instance\_id | EC2 instance ID |
 | tags | List of tags |
 | vpc\_security\_group\_ids | List of VPC security group ids assigned to the instances |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/volume-attachment/README.md
+++ b/examples/volume-attachment/README.md
@@ -32,6 +32,23 @@ Note that this example may create resources which can cost money. Run `terraform
 |------|---------|
 | aws | >= 2.65 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| ec2 | ../../ |  |
+| security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/data-sources/ami) |
+| [aws_ebs_volume](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/resources/ebs_volume) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/data-sources/subnet_ids) |
+| [aws_volume_attachment](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/resources/volume_attachment) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.65/docs/data-sources/vpc) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -45,5 +62,4 @@ Note that this example may create resources which can cost money. Run `terraform
 | ebs\_volume\_attachment\_id | The volume ID |
 | ebs\_volume\_attachment\_instance\_id | The instance ID |
 | instances\_public\_ips | Public IPs assigned to the EC2 instance |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
