### PR TITLE
chore: update documentation and pin `terraform_docs` version to avoid future changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-v0.12.0-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.47.0
+    rev: v1.48.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -96,91 +96,91 @@ data "aws_ami" "ubuntu-xenial" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
-| aws | >= 2.65 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.65 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.65 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.65 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) |
+| Name | Type |
+|------|------|
+| [aws_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| ami | ID of AMI to use for the instance | `string` | n/a | yes |
-| associate\_public\_ip\_address | If true, the EC2 instance will have associated public IP address | `bool` | `null` | no |
-| cpu\_credits | The credit option for CPU usage (unlimited or standard) | `string` | `"standard"` | no |
-| disable\_api\_termination | If true, enables EC2 Instance Termination Protection | `bool` | `false` | no |
-| ebs\_block\_device | Additional EBS block devices to attach to the instance | `list(map(string))` | `[]` | no |
-| ebs\_optimized | If true, the launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
-| ephemeral\_block\_device | Customize Ephemeral (also known as Instance Store) volumes on the instance | `list(map(string))` | `[]` | no |
-| get\_password\_data | If true, wait for password data to become available and retrieve it. | `bool` | `false` | no |
-| iam\_instance\_profile | The IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. | `string` | `""` | no |
-| instance\_count | Number of instances to launch | `number` | `1` | no |
-| instance\_initiated\_shutdown\_behavior | Shutdown behavior for the instance | `string` | `""` | no |
-| instance\_type | The type of instance to start | `string` | n/a | yes |
-| ipv6\_address\_count | A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet. | `number` | `null` | no |
-| ipv6\_addresses | Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `null` | no |
-| key\_name | The key name to use for the instance | `string` | `""` | no |
-| metadata\_options | Customize the metadata options of the instance | `map(string)` | `{}` | no |
-| monitoring | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
-| name | Name to be used on all resources as prefix | `string` | n/a | yes |
-| network\_interface | Customize network interfaces to be attached at instance boot time | `list(map(string))` | `[]` | no |
-| num\_suffix\_format | Numerical suffix format used as the volume and EC2 instance name suffix | `string` | `"-%d"` | no |
-| placement\_group | The Placement Group to start the instance in | `string` | `""` | no |
-| private\_ip | Private IP address to associate with the instance in a VPC | `string` | `null` | no |
-| private\_ips | A list of private IP address to associate with the instance in a VPC. Should match the number of instances. | `list(string)` | `[]` | no |
-| root\_block\_device | Customize details about the root block device of the instance. See Block Devices below for details | `list(map(string))` | `[]` | no |
-| source\_dest\_check | Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs. | `bool` | `true` | no |
-| subnet\_id | The VPC Subnet ID to launch in | `string` | `""` | no |
-| subnet\_ids | A list of VPC Subnet IDs to launch in | `list(string)` | `[]` | no |
-| tags | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
-| tenancy | The tenancy of the instance (if the instance is running in a VPC). Available values: default, dedicated, host. | `string` | `"default"` | no |
-| use\_num\_suffix | Always append numerical suffix to instance name, even if instance\_count is 1 | `bool` | `false` | no |
-| user\_data | The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user\_data\_base64 instead. | `string` | `null` | no |
-| user\_data\_base64 | Can be used instead of user\_data to pass base64-encoded binary data directly. Use this instead of user\_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption. | `string` | `null` | no |
-| volume\_tags | A mapping of tags to assign to the devices created by the instance at launch time | `map(string)` | `{}` | no |
-| vpc\_security\_group\_ids | A list of security group IDs to associate with | `list(string)` | `null` | no |
+| <a name="input_ami"></a> [ami](#input\_ami) | ID of AMI to use for the instance | `string` | n/a | yes |
+| <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | If true, the EC2 instance will have associated public IP address | `bool` | `null` | no |
+| <a name="input_cpu_credits"></a> [cpu\_credits](#input\_cpu\_credits) | The credit option for CPU usage (unlimited or standard) | `string` | `"standard"` | no |
+| <a name="input_disable_api_termination"></a> [disable\_api\_termination](#input\_disable\_api\_termination) | If true, enables EC2 Instance Termination Protection | `bool` | `false` | no |
+| <a name="input_ebs_block_device"></a> [ebs\_block\_device](#input\_ebs\_block\_device) | Additional EBS block devices to attach to the instance | `list(map(string))` | `[]` | no |
+| <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | If true, the launched EC2 instance will be EBS-optimized | `bool` | `false` | no |
+| <a name="input_ephemeral_block_device"></a> [ephemeral\_block\_device](#input\_ephemeral\_block\_device) | Customize Ephemeral (also known as Instance Store) volumes on the instance | `list(map(string))` | `[]` | no |
+| <a name="input_get_password_data"></a> [get\_password\_data](#input\_get\_password\_data) | If true, wait for password data to become available and retrieve it. | `bool` | `false` | no |
+| <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | The IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile. | `string` | `""` | no |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances to launch | `number` | `1` | no |
+| <a name="input_instance_initiated_shutdown_behavior"></a> [instance\_initiated\_shutdown\_behavior](#input\_instance\_initiated\_shutdown\_behavior) | Shutdown behavior for the instance | `string` | `""` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance to start | `string` | n/a | yes |
+| <a name="input_ipv6_address_count"></a> [ipv6\_address\_count](#input\_ipv6\_address\_count) | A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet. | `number` | `null` | no |
+| <a name="input_ipv6_addresses"></a> [ipv6\_addresses](#input\_ipv6\_addresses) | Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `null` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The key name to use for the instance | `string` | `""` | no |
+| <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Customize the metadata options of the instance | `map(string)` | `{}` | no |
+| <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name to be used on all resources as prefix | `string` | n/a | yes |
+| <a name="input_network_interface"></a> [network\_interface](#input\_network\_interface) | Customize network interfaces to be attached at instance boot time | `list(map(string))` | `[]` | no |
+| <a name="input_num_suffix_format"></a> [num\_suffix\_format](#input\_num\_suffix\_format) | Numerical suffix format used as the volume and EC2 instance name suffix | `string` | `"-%d"` | no |
+| <a name="input_placement_group"></a> [placement\_group](#input\_placement\_group) | The Placement Group to start the instance in | `string` | `""` | no |
+| <a name="input_private_ip"></a> [private\_ip](#input\_private\_ip) | Private IP address to associate with the instance in a VPC | `string` | `null` | no |
+| <a name="input_private_ips"></a> [private\_ips](#input\_private\_ips) | A list of private IP address to associate with the instance in a VPC. Should match the number of instances. | `list(string)` | `[]` | no |
+| <a name="input_root_block_device"></a> [root\_block\_device](#input\_root\_block\_device) | Customize details about the root block device of the instance. See Block Devices below for details | `list(map(string))` | `[]` | no |
+| <a name="input_source_dest_check"></a> [source\_dest\_check](#input\_source\_dest\_check) | Controls if traffic is routed to the instance when the destination address does not match the instance. Used for NAT or VPNs. | `bool` | `true` | no |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The VPC Subnet ID to launch in | `string` | `""` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of VPC Subnet IDs to launch in | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| <a name="input_tenancy"></a> [tenancy](#input\_tenancy) | The tenancy of the instance (if the instance is running in a VPC). Available values: default, dedicated, host. | `string` | `"default"` | no |
+| <a name="input_use_num_suffix"></a> [use\_num\_suffix](#input\_use\_num\_suffix) | Always append numerical suffix to instance name, even if instance\_count is 1 | `bool` | `false` | no |
+| <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The user data to provide when launching the instance. Do not pass gzip-compressed data via this argument; see user\_data\_base64 instead. | `string` | `null` | no |
+| <a name="input_user_data_base64"></a> [user\_data\_base64](#input\_user\_data\_base64) | Can be used instead of user\_data to pass base64-encoded binary data directly. Use this instead of user\_data whenever the value is not a valid UTF-8 string. For example, gzip-encoded user data must be base64-encoded and passed via this argument to avoid corruption. | `string` | `null` | no |
+| <a name="input_volume_tags"></a> [volume\_tags](#input\_volume\_tags) | A mapping of tags to assign to the devices created by the instance at launch time | `map(string)` | `{}` | no |
+| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | A list of security group IDs to associate with | `list(string)` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| arn | List of ARNs of instances |
-| availability\_zone | List of availability zones of instances |
-| credit\_specification | List of credit specification of instances |
-| ebs\_block\_device\_volume\_ids | List of volume IDs of EBS block devices of instances |
-| id | List of IDs of instances |
-| instance\_count | Number of instances to launch specified as argument to this module |
-| instance\_state | List of instance states of instances |
-| ipv6\_addresses | List of assigned IPv6 addresses of instances |
-| key\_name | List of key names of instances |
-| metadata\_options | List of metadata options of instances |
-| password\_data | List of Base-64 encoded encrypted password data for the instance |
-| placement\_group | List of placement groups of instances |
-| primary\_network\_interface\_id | List of IDs of the primary network interface of instances |
-| private\_dns | List of private DNS names assigned to the instances. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC |
-| private\_ip | List of private IP addresses assigned to the instances |
-| public\_dns | List of public DNS names assigned to the instances. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC |
-| public\_ip | List of public IP addresses assigned to the instances, if applicable |
-| root\_block\_device\_volume\_ids | List of volume IDs of root block devices of instances |
-| security\_groups | List of associated security groups of instances |
-| subnet\_id | List of IDs of VPC subnets of instances |
-| tags | List of tags of instances |
-| volume\_tags | List of tags of volumes of instances |
-| vpc\_security\_group\_ids | List of associated security groups of instances, if running in non-default VPC |
+| <a name="output_arn"></a> [arn](#output\_arn) | List of ARNs of instances |
+| <a name="output_availability_zone"></a> [availability\_zone](#output\_availability\_zone) | List of availability zones of instances |
+| <a name="output_credit_specification"></a> [credit\_specification](#output\_credit\_specification) | List of credit specification of instances |
+| <a name="output_ebs_block_device_volume_ids"></a> [ebs\_block\_device\_volume\_ids](#output\_ebs\_block\_device\_volume\_ids) | List of volume IDs of EBS block devices of instances |
+| <a name="output_id"></a> [id](#output\_id) | List of IDs of instances |
+| <a name="output_instance_count"></a> [instance\_count](#output\_instance\_count) | Number of instances to launch specified as argument to this module |
+| <a name="output_instance_state"></a> [instance\_state](#output\_instance\_state) | List of instance states of instances |
+| <a name="output_ipv6_addresses"></a> [ipv6\_addresses](#output\_ipv6\_addresses) | List of assigned IPv6 addresses of instances |
+| <a name="output_key_name"></a> [key\_name](#output\_key\_name) | List of key names of instances |
+| <a name="output_metadata_options"></a> [metadata\_options](#output\_metadata\_options) | List of metadata options of instances |
+| <a name="output_password_data"></a> [password\_data](#output\_password\_data) | List of Base-64 encoded encrypted password data for the instance |
+| <a name="output_placement_group"></a> [placement\_group](#output\_placement\_group) | List of placement groups of instances |
+| <a name="output_primary_network_interface_id"></a> [primary\_network\_interface\_id](#output\_primary\_network\_interface\_id) | List of IDs of the primary network interface of instances |
+| <a name="output_private_dns"></a> [private\_dns](#output\_private\_dns) | List of private DNS names assigned to the instances. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | List of private IP addresses assigned to the instances |
+| <a name="output_public_dns"></a> [public\_dns](#output\_public\_dns) | List of public DNS names assigned to the instances. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC |
+| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | List of public IP addresses assigned to the instances, if applicable |
+| <a name="output_root_block_device_volume_ids"></a> [root\_block\_device\_volume\_ids](#output\_root\_block\_device\_volume\_ids) | List of volume IDs of root block devices of instances |
+| <a name="output_security_groups"></a> [security\_groups](#output\_security\_groups) | List of associated security groups of instances |
+| <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | List of IDs of VPC subnets of instances |
+| <a name="output_tags"></a> [tags](#output\_tags) | List of tags of instances |
+| <a name="output_volume_tags"></a> [volume\_tags](#output\_volume\_tags) | List of tags of volumes of instances |
+| <a name="output_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#output\_vpc\_security\_group\_ids) | List of associated security groups of instances, if running in non-default VPC |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -19,60 +19,60 @@ Note that this example may create resources which can cost money. Run `terraform
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
-| aws | >= 2.65 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.65 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.65 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.65 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| ec2 | ../../ |  |
-| ec2_with_metadata_options | ../../ |  |
-| ec2_with_network_interface | ../../ |  |
-| ec2_with_t2_unlimited | ../../ |  |
-| ec2_with_t3_unlimited | ../../ |  |
-| ec2_zero | ../../ |  |
-| security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
+| <a name="module_ec2"></a> [ec2](#module\_ec2) | ../../ |  |
+| <a name="module_ec2_with_metadata_options"></a> [ec2\_with\_metadata\_options](#module\_ec2\_with\_metadata\_options) | ../../ |  |
+| <a name="module_ec2_with_network_interface"></a> [ec2\_with\_network\_interface](#module\_ec2\_with\_network\_interface) | ../../ |  |
+| <a name="module_ec2_with_t2_unlimited"></a> [ec2\_with\_t2\_unlimited](#module\_ec2\_with\_t2\_unlimited) | ../../ |  |
+| <a name="module_ec2_with_t3_unlimited"></a> [ec2\_with\_t3\_unlimited](#module\_ec2\_with\_t3\_unlimited) | ../../ |  |
+| <a name="module_ec2_zero"></a> [ec2\_zero](#module\_ec2\_zero) | ../../ |  |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3.0 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
-| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) |
-| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) |
-| [aws_network_interface](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) |
-| [aws_placement_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/placement_group) |
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+| Name | Type |
+|------|------|
+| [aws_eip.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_network_interface.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
+| [aws_placement_group.web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/placement_group) | resource |
+| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| credit\_specification | Credit specification of EC2 instance (empty list for not t2 instance types) |
-| credit\_specification\_t2\_unlimited | Credit specification of t2-type EC2 instance |
-| ebs\_block\_device\_volume\_ids | List of volume IDs of EBS block devices of instances |
-| ids | List of IDs of instances |
-| ids\_t2 | List of IDs of t2-type instances |
-| instance\_id | EC2 instance ID |
-| instance\_public\_dns | Public DNS name assigned to the EC2 instance |
-| metadata\_options | Metadata options for the instance |
-| metadata\_options\_custom | Customized metadata options for the instance |
-| placement\_group | List of placement group |
-| public\_dns | List of public DNS names assigned to the instances |
-| root\_block\_device\_volume\_ids | List of volume IDs of root block devices of instances |
-| t2\_instance\_id | EC2 instance ID |
-| tags | List of tags |
-| vpc\_security\_group\_ids | List of VPC security group ids assigned to the instances |
+| <a name="output_credit_specification"></a> [credit\_specification](#output\_credit\_specification) | Credit specification of EC2 instance (empty list for not t2 instance types) |
+| <a name="output_credit_specification_t2_unlimited"></a> [credit\_specification\_t2\_unlimited](#output\_credit\_specification\_t2\_unlimited) | Credit specification of t2-type EC2 instance |
+| <a name="output_ebs_block_device_volume_ids"></a> [ebs\_block\_device\_volume\_ids](#output\_ebs\_block\_device\_volume\_ids) | List of volume IDs of EBS block devices of instances |
+| <a name="output_ids"></a> [ids](#output\_ids) | List of IDs of instances |
+| <a name="output_ids_t2"></a> [ids\_t2](#output\_ids\_t2) | List of IDs of t2-type instances |
+| <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | EC2 instance ID |
+| <a name="output_instance_public_dns"></a> [instance\_public\_dns](#output\_instance\_public\_dns) | Public DNS name assigned to the EC2 instance |
+| <a name="output_metadata_options"></a> [metadata\_options](#output\_metadata\_options) | Metadata options for the instance |
+| <a name="output_metadata_options_custom"></a> [metadata\_options\_custom](#output\_metadata\_options\_custom) | Customized metadata options for the instance |
+| <a name="output_placement_group"></a> [placement\_group](#output\_placement\_group) | List of placement group |
+| <a name="output_public_dns"></a> [public\_dns](#output\_public\_dns) | List of public DNS names assigned to the instances |
+| <a name="output_root_block_device_volume_ids"></a> [root\_block\_device\_volume\_ids](#output\_root\_block\_device\_volume\_ids) | List of volume IDs of root block devices of instances |
+| <a name="output_t2_instance_id"></a> [t2\_instance\_id](#output\_t2\_instance\_id) | EC2 instance ID |
+| <a name="output_tags"></a> [tags](#output\_tags) | List of tags |
+| <a name="output_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#output\_vpc\_security\_group\_ids) | List of VPC security group ids assigned to the instances |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/volume-attachment/README.md
+++ b/examples/volume-attachment/README.md
@@ -23,43 +23,43 @@ Note that this example may create resources which can cost money. Run `terraform
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6 |
-| aws | >= 2.65 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.65 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.65 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.65 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| ec2 | ../../ |  |
-| security_group | terraform-aws-modules/security-group/aws | ~> 3.0 |
+| <a name="module_ec2"></a> [ec2](#module\_ec2) | ../../ |  |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 3.0 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
-| [aws_ebs_volume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) |
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
-| [aws_volume_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+| Name | Type |
+|------|------|
+| [aws_ebs_volume.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
+| [aws_volume_attachment.this_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
+| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_subnet_ids.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| instances\_number | NUmber of instances | `number` | `1` | no |
+| <a name="input_instances_number"></a> [instances\_number](#input\_instances\_number) | NUmber of instances | `number` | `1` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| ebs\_volume\_attachment\_id | The volume ID |
-| ebs\_volume\_attachment\_instance\_id | The instance ID |
-| instances\_public\_ips | Public IPs assigned to the EC2 instance |
+| <a name="output_ebs_volume_attachment_id"></a> [ebs\_volume\_attachment\_id](#output\_ebs\_volume\_attachment\_id) | The volume ID |
+| <a name="output_ebs_volume_attachment_instance_id"></a> [ebs\_volume\_attachment\_instance\_id](#output\_ebs\_volume\_attachment\_instance\_id) | The instance ID |
+| <a name="output_instances_public_ips"></a> [instances\_public\_ips](#output\_instances\_public\_ips) | Public IPs assigned to the EC2 instance |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation and pin `terraform_docs` version to avoid future changes

## Motivation and Context
- pin version to avoid unnecessary updates when a PR coincides with a version update for `terraform_docs`

## Breaking Changes
- no

## How Has This Been Tested?
- documentation change only - ci/cd should pass checks
