### PR TITLE
fix: Add support for ebs throughput

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ resource "aws_instance" "this" {
       delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
       encrypted             = lookup(root_block_device.value, "encrypted", null)
       iops                  = lookup(root_block_device.value, "iops", null)
+      throughput            = lookup(root_block_device.value, "throughput", null)
       kms_key_id            = lookup(root_block_device.value, "kms_key_id", null)
       volume_size           = lookup(root_block_device.value, "volume_size", null)
       volume_type           = lookup(root_block_device.value, "volume_type", null)
@@ -46,6 +47,7 @@ resource "aws_instance" "this" {
       device_name           = ebs_block_device.value.device_name
       encrypted             = lookup(ebs_block_device.value, "encrypted", null)
       iops                  = lookup(ebs_block_device.value, "iops", null)
+      throughput            = lookup(ebs_block_device.value, "throughput", null)
       kms_key_id            = lookup(ebs_block_device.value, "kms_key_id", null)
       snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
       volume_size           = lookup(ebs_block_device.value, "volume_size", null)


### PR DESCRIPTION
## Description
Support creation of EBS volume with specified throughput rates. Related to issue #226

## Motivation and Context
AWS EBS GP3 volume supports configuring of throughput and IOPS to achieve better disk performance. 
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume

## Breaking Changes
None

