### PR TITLE
feat: Add support for EBS GP3 throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ data "aws_ami" "ubuntu-xenial" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.24 |
 
 ## Modules
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -26,19 +26,19 @@ Note that this example may create resources which can cost money. Run `terraform
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.65 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2"></a> [ec2](#module\_ec2) | ../../ | n/a |
-| <a name="module_ec2_optimize_cpu"></a> [ec2\_optimize\_cpu](#module\_ec2\_optimize\_cpu) | ../../ | n/a |
-| <a name="module_ec2_with_metadata_options"></a> [ec2\_with\_metadata\_options](#module\_ec2\_with\_metadata\_options) | ../../ | n/a |
-| <a name="module_ec2_with_network_interface"></a> [ec2\_with\_network\_interface](#module\_ec2\_with\_network\_interface) | ../../ | n/a |
-| <a name="module_ec2_with_t2_unlimited"></a> [ec2\_with\_t2\_unlimited](#module\_ec2\_with\_t2\_unlimited) | ../../ | n/a |
-| <a name="module_ec2_with_t3_unlimited"></a> [ec2\_with\_t3\_unlimited](#module\_ec2\_with\_t3\_unlimited) | ../../ | n/a |
-| <a name="module_ec2_zero"></a> [ec2\_zero](#module\_ec2\_zero) | ../../ | n/a |
+| <a name="module_ec2"></a> [ec2](#module\_ec2) | ../../ |  |
+| <a name="module_ec2_optimize_cpu"></a> [ec2\_optimize\_cpu](#module\_ec2\_optimize\_cpu) | ../../ |  |
+| <a name="module_ec2_with_metadata_options"></a> [ec2\_with\_metadata\_options](#module\_ec2\_with\_metadata\_options) | ../../ |  |
+| <a name="module_ec2_with_network_interface"></a> [ec2\_with\_network\_interface](#module\_ec2\_with\_network\_interface) | ../../ |  |
+| <a name="module_ec2_with_t2_unlimited"></a> [ec2\_with\_t2\_unlimited](#module\_ec2\_with\_t2\_unlimited) | ../../ |  |
+| <a name="module_ec2_with_t3_unlimited"></a> [ec2\_with\_t3\_unlimited](#module\_ec2\_with\_t3\_unlimited) | ../../ |  |
+| <a name="module_ec2_zero"></a> [ec2\_zero](#module\_ec2\_zero) | ../../ |  |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 
 ## Resources

--- a/examples/volume-attachment/README.md
+++ b/examples/volume-attachment/README.md
@@ -30,13 +30,13 @@ Note that this example may create resources which can cost money. Run `terraform
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.55.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.65 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2"></a> [ec2](#module\_ec2) | ../../ | n/a |
+| <a name="module_ec2"></a> [ec2](#module\_ec2) | ../../ |  |
 | <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
 
 ## Resources


### PR DESCRIPTION
Fixes #226

## Description
Added the mapping of throughput in the dynamic root block and ebs block device objects

## Motivation and Context
This will allow to provision gp3 volumes with the capacity to define the required throughput

## Breaking Changes
No breaking changes foreseen.
I did not implement checks on volume type since the AWS API will error out in case this is specified for a non gp3 ebs volume.

## How Has This Been Tested?
- [X ] I have tested and validated these changes using one or more of the provided `examples/*` projects
I have changed the basic example to have it deploy gp3 volumes for the root and also for additional ebs and also included throughtput values.
I have also tested a case where user input is incorrect ie setting volume type to gp2 and setting the throughput.
=> AWS API error is clear enough to guide the end user to correct his/her inputs : 

Error: error collecting instance settings: error creating resource: throughput attribute not supported for ebs_block_device with volume_type gp2

Please feel free to provide your feedback I'd be happy to take it into account.

Thanks.

Bests.
