### PR TITLE
feat: Add instance private IP to the outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ No modules.
 | <a name="output_password_data"></a> [password\_data](#output\_password\_data) | Base-64 encoded encrypted password data for the instance. Useful for getting the administrator password for instances running Microsoft Windows. This attribute is only exported if `get_password_data` is true |
 | <a name="output_primary_network_interface_id"></a> [primary\_network\_interface\_id](#output\_primary\_network\_interface\_id) | The ID of the instance's primary network interface |
 | <a name="output_private_dns"></a> [private\_dns](#output\_private\_dns) | The private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | The private IP address assigned to the instance. |
 | <a name="output_public_dns"></a> [public\_dns](#output\_public\_dns) | The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC |
 | <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | The public IP address assigned to the instance, if applicable. NOTE: If you are using an aws\_eip with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached |
 | <a name="output_spot_bid_status"></a> [spot\_bid\_status](#output\_spot\_bid\_status) | The current bid status of the Spot Instance Request |

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,6 +48,11 @@ output "public_ip" {
   value       = element(concat(aws_instance.this.*.public_ip, aws_spot_instance_request.this.*.public_ip, [""]), 0)
 }
 
+output "private_ip" {
+  description = "The private IP address assigned to the instance."
+  value       = element(concat(aws_instance.this.*.private_ip, aws_spot_instance_request.this.*.private_ip, [""]), 0)
+}
+
 output "tags_all" {
   description = "A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block"
   value       = element(concat(aws_instance.this.*.tags_all, aws_spot_instance_request.this.*.tags_all, [""]), 0)


### PR DESCRIPTION
## Description

Added an output for the `private_ip` of the aws instance(s), similar to the `public_ip`.

## Motivation and Context

I need the private IP as an output for referencing,

## Breaking Changes

None

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->

I tested against the `volume-attachment` example.

Also,

After discovering the module doesn't have a `private_ip` output. I cloned my fork, changed the `source` of the module in my original project to point to my local clone, and then re-ran `terraform`. The `private_ip` of the instance was then outputed.


<!--- Include details of your testing environment, and the tests you ran to -->
```bash
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # aws_ebs_volume.volume["eu-central-1a"] will be updated in-place
  ~ resource "aws_ebs_volume" "volume" {
        id                   = "<redacted>"
      ~ tags                 = {
          + "purpose" = "<redacted>"
            # (1 unchanged element hidden)
        }
        # (9 unchanged attributes hidden)
    }

  # aws_ebs_volume.volume["eu-central-1b"] will be updated in-place
  ~ resource "aws_ebs_volume" "volume" {
        id                   = "<redacted>"
      ~ tags                 = {
          + "purpose" = "<redacted>"
            # (1 unchanged element hidden)
        }
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.

Changes to Outputs:
  + ec2 = "10.64.0.221"

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: no

Apply cancelled.
```
```bash
❯ terraform --version
Terraform v1.0.0
on linux_amd64
+ provider registry.terraform.io/hashicorp/aws v3.51.0
+ provider registry.terraform.io/hashicorp/local v2.1.0
+ provider registry.terraform.io/hashicorp/tls v3.1.0

Your version of Terraform is out of date! The latest version
is 1.0.8. You can update by downloading from https://www.terraform.io/downloads.html
❯ terragrunt --version
```

<!--- see how your change affects other areas of the code, etc. -->
