### PR TITLE
feat: Add `instance_metadata_tags` attribute and bump AWS provider to support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,13 @@ The following combinations are supported to conditionally create resources:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.51 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.51 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which can cost money. Run `terraform
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.51 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.51 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -169,6 +169,7 @@ module "ec2_metadata_options" {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
     http_put_response_hop_limit = 8
+    instance_metadata_tags      = "enabled"
   }
 
   tags = local.tags

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.51"
+      version = ">= 3.72"
     }
   }
 }

--- a/examples/volume-attachment/README.md
+++ b/examples/volume-attachment/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which can cost money. Run `terraform
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.51 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.51 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
 
 ## Modules
 

--- a/examples/volume-attachment/versions.tf
+++ b/examples/volume-attachment/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.51"
+      version = ">= 3.72"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ resource "aws_instance" "this" {
       http_endpoint               = lookup(metadata_options.value, "http_endpoint", "enabled")
       http_tokens                 = lookup(metadata_options.value, "http_tokens", "optional")
       http_put_response_hop_limit = lookup(metadata_options.value, "http_put_response_hop_limit", "1")
+      instance_metadata_tags      = lookup(metadata_options.value, "instance_metadata_tags", null)
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.51"
+      version = ">= 3.72"
     }
   }
 }


### PR DESCRIPTION
## Description
- add `instance_metadata_tags` attribute and bump AWS provider to support

## Motivation and Context
- AWS now allows users to attach/query tags via the metadata endpoint service

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
	- `complete` example
