### PR TITLE
Adding lifecycle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,15 @@ resource "aws_instance" "this" {
     }
   }
 
+  dynamic "lifecycle" {
+    for_each       = var.ignore_user_data_changes == true ? [1] : []
+    content {
+      ignore_changes = [
+        user_data, user_data_base64
+      ]
+    }
+  }
+
   enclave_options {
     enabled = var.enclave_options_enabled
   }
@@ -129,12 +138,6 @@ resource "aws_instance" "this" {
     create = lookup(var.timeouts, "create", null)
     update = lookup(var.timeouts, "update", null)
     delete = lookup(var.timeouts, "delete", null)
-  }
-
-  lifecycle {
-    ignore_changes = [
-      user_data, user_data_base64
-    ]
   }
 
   tags        = merge({ "Name" = var.name }, var.tags)
@@ -259,6 +262,15 @@ resource "aws_spot_instance_request" "this" {
     }
   }
 
+  dynamic "lifecycle" {
+    for_each       = var.ignore_user_data_changes == true ? [1] : []
+    content {
+      ignore_changes = [
+        user_data, user_data_base64
+      ]
+    }
+  }
+
   enclave_options {
     enabled = var.enclave_options_enabled
   }
@@ -277,12 +289,6 @@ resource "aws_spot_instance_request" "this" {
   timeouts {
     create = lookup(var.timeouts, "create", null)
     delete = lookup(var.timeouts, "delete", null)
-  }
-
-  lifecycle {
-    ignore_changes = [
-      user_data, user_data_base64
-    ]
   }
 
   tags        = merge({ "Name" = var.name }, var.tags)

--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,12 @@ resource "aws_instance" "this" {
     delete = lookup(var.timeouts, "delete", null)
   }
 
+  lifecycle {
+    ignore_changes = [
+      user_data, user_data_base64
+    ]
+  }
+
   tags        = merge({ "Name" = var.name }, var.tags)
   volume_tags = var.enable_volume_tags ? merge({ "Name" = var.name }, var.volume_tags) : null
 }
@@ -271,6 +277,12 @@ resource "aws_spot_instance_request" "this" {
   timeouts {
     create = lookup(var.timeouts, "create", null)
     delete = lookup(var.timeouts, "delete", null)
+  }
+
+  lifecycle {
+    ignore_changes = [
+      user_data, user_data_base64
+    ]
   }
 
   tags        = merge({ "Name" = var.name }, var.tags)

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,12 @@ variable "iam_instance_profile" {
   default     = null
 }
 
+variable "ignore_user_data_changes" {
+  description = "Enable if you don't want that User Data changes will destroy your instance"
+  type        = bool
+  default     = false
+}
+
 variable "instance_initiated_shutdown_behavior" {
   description = "Shutdown behavior for the instance. Amazon defaults this to stop for EBS-backed instances and terminate for instance-store instances. Cannot be set on instance-store instance" # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior
   type        = string


### PR DESCRIPTION
## Description
Added a lifecycle argument for user_data and user_data_base64

## Motivation and Context
Adding a lifecycle for user_data and user_data_base64 should help while you don't want that changing the user_data will destroy your EC2 instance. Therefore the Lifecycle argument is being used dynamically, that if you do want it to destroy your EC2 instance, you will be able to get it.

## Breaking Changes
No break

## How Has This Been Tested?
Tested it locally and worked.
