### PR TITLE
feat: Adding `availability_zone` to the outputs of the module

### DIFF
--- a/examples/volume-attachment/main.tf
+++ b/examples/volume-attachment/main.tf
@@ -82,7 +82,7 @@ resource "aws_volume_attachment" "this" {
 }
 
 resource "aws_ebs_volume" "this" {
-  availability_zone = local.availability_zone
+  availability_zone = module.ec2.availability_zone
   size              = 1
 
   tags = local.tags

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "arn" {
   value       = try(aws_instance.this[0].arn, aws_spot_instance_request.this[0].arn, "")
 }
 
+output "availability_zone" {
+  description = "The availability zone of the instance"
+  value       = try(aws_instance.this[0].availability_zone, aws_spot_instance_request.this[0].availability_zone, "")
+}
+
 output "capacity_reservation_specification" {
   description = "Capacity reservation specification of the instance"
   value       = try(aws_instance.this[0].capacity_reservation_specification, aws_spot_instance_request.this[0].capacity_reservation_specification, "")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The `availability_zone` of the instance is very useful information to use outside of the module. This PR provides that information.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When creating an external or auxiliary `aws_ebs_volume` for the EC2 instance, it requires an availability zone argument. Often times, we would like to have the EBS volume in the same AZ as the EC2. Having that information would make that design much easier. 
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #264

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
None
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
In terraform, I declared a ec2 module with my revisions and used the outputs for aws_volume_attachment and aws_ebs_volume arguements:

```hcl
module "kennedy" {
  source               = "github.com/kennedy/terraform-aws-ec2-instance?ref=kennedy-adding-availability-zone"
  ...
  # AMI image has one EBS volume mapping, no additional ebs block is declared
  
  root_block_device = [
    {
      volume_type = "gp2"
      volume_size = 100
    },
  ]
}

resource "aws_volume_attachment" "kennedy" {
  device_name = "/dev/sdh"
  volume_id   = aws_ebs_volume.kennedy.id
  instance_id = module.kennedy.id
}

resource "aws_ebs_volume" "kennedy" {
  availability_zone = module.kennedy.availability_zone
  size              = 500
}
```

<!--- Include details of your testing environment, and the tests you ran to -->
Environment:

```
macOS 12.2
Terraform v0.13.7
+ provider registry.terraform.io/hashicorp/aws v3.74.3
+ provider registry.terraform.io/hashicorp/local v2.1.0
+ provider registry.terraform.io/hashicorp/null v3.1.0
+ provider registry.terraform.io/hashicorp/random v3.1.0
```

```bash
terraform plan --target aws_volume_attachment.kennedy --target aws_ebs_volume.kennedy --target module.kennedy
...
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ebs_volume.kennedy will be created
  + resource "aws_ebs_volume" "kennedy" {
      + arn               = (known after apply)
      + availability_zone = (known after apply)
      + encrypted         = (known after apply)
      + id                = (known after apply)
      + iops              = (known after apply)
      + kms_key_id        = (known after apply)
      + size              = 500
      + snapshot_id       = (known after apply)
      + tags_all          = {
            ...
        }
      + throughput        = (known after apply)
      + type              = (known after apply)
    }

  # aws_volume_attachment.kennedy will be created
  + resource "aws_volume_attachment" "kennedy" {
      + device_name = "/dev/sdh"
      + id          = (known after apply)
      + instance_id = (known after apply)
      + volume_id   = (known after apply)
    }

  # module.kennedy.aws_instance.this[0] will be created
  + resource "aws_instance" "this" {
      + ami                                  = "ami-redacted"
      # AMI image has one pre-exisiting EBS volume mapping

...
      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

...

      + root_block_device {
          + delete_on_termination = true
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = 100
          + volume_type           = "gp2"
        }

      + timeouts {}
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```