### PR TITLE
feat: Adding EBS devices without overriding existing EBS mappings

### DIFF
--- a/examples/multi-ec2-with-external-attachment/README.md
+++ b/examples/multi-ec2-with-external-attachment/README.md
@@ -1,0 +1,66 @@
+# Multi EC2 instances with auxiliary EBS volume attachments
+
+Configuration in this directory creates EC2 instances with auxiliary EBS volumes attached, without overriding AMI's pre-mapped EBS devices.
+
+This example outputs instance ids along with their auxiliary EBS volume ids.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.72 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.72 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_ec2"></a> [ec2](#module\_ec2) | ../../ | n/a |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 4.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ebs_volume.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
+| [aws_volume_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
+| [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_ec2_arn"></a> [ec2\_arn](#output\_ec2\_arn) | The ARN of the instance |
+| <a name="output_ec2_capacity_reservation_specification"></a> [ec2\_capacity\_reservation\_specification](#output\_ec2\_capacity\_reservation\_specification) | Capacity reservation specification of the instance |
+| <a name="output_ec2_id"></a> [ec2\_id](#output\_ec2\_id) | The ID of the instance |
+| <a name="output_ec2_instance_state"></a> [ec2\_instance\_state](#output\_ec2\_instance\_state) | The state of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped` |
+| <a name="output_ec2_primary_network_interface_id"></a> [ec2\_primary\_network\_interface\_id](#output\_ec2\_primary\_network\_interface\_id) | The ID of the instance's primary network interface |
+| <a name="output_ec2_private_dns"></a> [ec2\_private\_dns](#output\_ec2\_private\_dns) | The private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC |
+| <a name="output_ec2_public_dns"></a> [ec2\_public\_dns](#output\_ec2\_public\_dns) | The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC |
+| <a name="output_ec2_public_ip"></a> [ec2\_public\_ip](#output\_ec2\_public\_ip) | The public IP address assigned to the instance, if applicable. NOTE: If you are using an aws\_eip with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached |
+| <a name="output_ec2_tags_all"></a> [ec2\_tags\_all](#output\_ec2\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider default\_tags configuration block |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multi-ec2-with-external-attachment/main.tf
+++ b/examples/multi-ec2-with-external-attachment/main.tf
@@ -1,0 +1,162 @@
+provider "aws" {
+  region = local.region
+  default_tags {
+    tags = {
+      Owner       = "user"
+      Environment = "dev"
+    }
+  }
+}
+
+locals {
+  availability_zone = "${local.region}a"
+  name              = "example-ec2-volume-attachment"
+  region            = "us-east-1"
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = local.name
+  cidr = "10.99.0.0/18"
+
+  azs              = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  public_subnets   = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
+  private_subnets  = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
+  database_subnets = ["10.99.7.0/24", "10.99.8.0/24", "10.99.9.0/24"]
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+module "security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.0"
+
+  name        = local.name
+  description = "Security group for example usage with EC2 instance"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+  ingress_rules       = ["http-80-tcp", "all-icmp"]
+  egress_rules        = ["all-all"]
+}
+
+################################################################################
+# EC2 Module - multiple instances with `for_each` and external attachments
+################################################################################
+
+locals {
+  multiple_instances = {
+    one = {
+      instance_type = "t3.micro"
+      subnet_id     = element(module.vpc.private_subnets, 0)
+      root_block_device = [
+        {
+          encrypted   = true
+          volume_type = "gp3"
+          throughput  = 200
+          volume_size = 50
+          tags = {
+            Name = "my-root-block"
+          }
+        }
+      ]
+      ebs_block_device = [
+        {
+          device_name       = "/dev/sdf"
+          volume_type       = "gp3"
+          volume_size       = 5
+          throughput        = 200
+          encrypted         = true
+          availability_zone = element(module.vpc.azs, 0)
+          }, {
+          device_name       = "/dev/sdh"
+          volume_type       = "gp3"
+          volume_size       = 10
+          throughput        = 200
+          encrypted         = true
+          availability_zone = element(module.vpc.azs, 0)
+        },
+      ]
+    }
+    two = {
+      instance_type = "t3.small"
+      subnet_id     = element(module.vpc.private_subnets, 1)
+      root_block_device = [
+        {
+          encrypted   = true
+          volume_type = "gp2"
+          volume_size = 50
+        }
+      ]
+      ebs_block_device = [
+        {
+          device_name = "/dev/sdf"
+          volume_type = "gp3"
+          volume_size = 5
+          throughput  = 200
+          encrypted   = true
+          }, {
+          device_name = "/dev/sdh"
+          volume_type = "gp3"
+          volume_size = 10
+          throughput  = 200
+          encrypted   = true
+        },
+      ]
+    }
+    three = {
+      instance_type = "t3.medium"
+      subnet_id     = element(module.vpc.private_subnets, 2)
+      ebs_block_device = [
+        {
+          device_name = "/dev/sdf"
+          volume_type = "gp3"
+          volume_size = 5
+          throughput  = 200
+          encrypted   = true
+          }, {
+          device_name = "/dev/sdh"
+          volume_type = "gp3"
+          volume_size = 10
+          throughput  = 200
+          encrypted   = true
+        },
+      ]
+    }
+  }
+}
+
+module "ec2_multiple" {
+  source = "../../"
+
+  for_each = local.multiple_instances
+
+  name = "${local.name}-multi-${each.key}"
+
+  ami                    = data.aws_ami.amazon_linux.id
+  instance_type          = each.value.instance_type
+  subnet_id              = each.value.subnet_id
+  vpc_security_group_ids = [module.security_group.security_group_id]
+
+  enable_volume_tags = false
+  root_block_device  = lookup(each.value, "root_block_device", [])
+
+  override_ebs_mapping = false
+  ebs_block_device     = lookup(each.value, "ebs_block_device", [])
+
+  tags = {}
+}

--- a/examples/multi-ec2-with-external-attachment/outputs.tf
+++ b/examples/multi-ec2-with-external-attachment/outputs.tf
@@ -1,0 +1,5 @@
+# EC2 Multiple
+output "ec2_multiple" {
+  description = "The full output of the `ec2_module` module with `external_ebs_block_device`"
+  value       = module.ec2_multiple
+}

--- a/examples/multi-ec2-with-external-attachment/versions.tf
+++ b/examples/multi-ec2-with-external-attachment/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.72"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "capacity_reservation_specification" {
   value       = try(aws_instance.this[0].capacity_reservation_specification, aws_spot_instance_request.this[0].capacity_reservation_specification, "")
 }
 
+output "external_ebs_block_device" {
+  description = "If override_ebs_mapping is false, EBS devices assigned along side the instance"
+  value       = try(aws_ebs_volume.this.*.id, [])
+}
+
 output "instance_state" {
   description = "The state of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped`"
   value       = try(aws_instance.this[0].instance_state, aws_spot_instance_request.this[0].instance_state, "")

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,12 @@ variable "ebs_block_device" {
   default     = []
 }
 
+variable "override_ebs_mapping" {
+  description = "Override non-root EBS block devices for the instance"
+  type        = bool
+  default     = true
+}
+
 variable "ebs_optimized" {
   description = "If true, the launched EC2 instance will be EBS-optimized"
   type        = bool


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Add a new variable `override_ebs_mapping` (default: `true`)
- If `override_ebs_mapping` is `false`, it would create `ebs_block_device` resources external to the `aws_instance` and assigns it

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
By design, if `ebs_block_device` is defined in the `aws_instance`, Terraform will assume management over the full set of non-root EBS block devices for the instance, treating additional block devices as drift.
With this PR, setting the variable `override_ebs_mapping` to `false` will allowing the user to create the `ebs_block_device` resources externally, leaving the pre-assigned/existing EBS device mapped in the AMI.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#argument-reference

> If you use `ebs_block_device` on an `aws_instance`, Terraform will assume management over the full set of non-root EBS block devices for the instance, and treats additional block devices as drift. For this reason, `ebs_block_device` cannot be mixed with external `aws_ebs_volume` + `aws_ebs_volume_attachment` resources for a given instance.

<!--- If it fixes an open issue, please link to the issue here. -->
Resolves:

- #263
- #214

Relates to:

- https://github.com/hashicorp/terraform-provider-aws/issues/20305
- https://github.com/hashicorp/terraform-provider-aws/issues/21806 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No breaking changes, the default value of `override_ebs_mapping` allows the module to behave as before.
<!-- If so, please provide an explanation why it is necessary. -->
There is an additional outputs, `outputs.external_ebs_block_device`

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
I created a new example, `examples\multi-ec2-with-external-attachment`, with `override_ebs_mapping` set to `false` and assigned two additional EBS devices to each ec2 instance. I also ran `examples\[complete,volume-attachment]`.
<!--- Include details of your testing environment, and the tests you ran to -->
```
Terraform v1.1.6
on windows_amd64
+ provider registry.terraform.io/hashicorp/aws v4.2.0
```
<!--- see how your change affects other areas of the code, etc. -->
