### PR TITLE
feat: Add support for `disable_api_stop` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ No modules.
 | <a name="input_cpu_threads_per_core"></a> [cpu\_threads\_per\_core](#input\_cpu\_threads\_per\_core) | Sets the number of CPU threads per core for an instance (has no effect unless cpu\_core\_count is also set). | `number` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create an instance | `bool` | `true` | no |
 | <a name="input_create_spot_instance"></a> [create\_spot\_instance](#input\_create\_spot\_instance) | Depicts if the instance is a spot instance | `bool` | `false` | no |
+| <a name="input_disable_api_stop"></a> [disable\_api\_stop](#input\_disable\_api\_stop) | If true, enables EC2 Instance Stop Protection. | `bool` | `null` | no |
 | <a name="input_disable_api_termination"></a> [disable\_api\_termination](#input\_disable\_api\_termination) | If true, enables EC2 Instance Termination Protection | `bool` | `null` | no |
 | <a name="input_ebs_block_device"></a> [ebs\_block\_device](#input\_ebs\_block\_device) | Additional EBS block devices to attach to the instance | `list(map(string))` | `[]` | no |
 | <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | If true, the launched EC2 instance will be EBS-optimized | `bool` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -168,13 +168,13 @@ The following combinations are supported to conditionally create resources:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.20.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.20.0 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 locals {
   name   = "example-ec2-complete"
-  region = "eu-west-1"
+  region = "us-east-1"
 
   user_data = <<-EOT
   #!/bin/bash
@@ -95,6 +95,7 @@ module "ec2_complete" {
   vpc_security_group_ids      = [module.security_group.security_group_id]
   placement_group             = aws_placement_group.web.id
   associate_public_ip_address = true
+  disable_api_stop            = false
 
   # only one of these can be enabled at a time
   hibernation = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 locals {
   name   = "example-ec2-complete"
-  region = "us-east-1"
+  region = "eu-west-1"
 
   user_data = <<-EOT
   #!/bin/bash

--- a/main.tf
+++ b/main.tf
@@ -120,6 +120,7 @@ resource "aws_instance" "this" {
 
   source_dest_check                    = length(var.network_interface) > 0 ? null : var.source_dest_check
   disable_api_termination              = var.disable_api_termination
+  disable_api_stop                     = var.disable_api_stop
   instance_initiated_shutdown_behavior = var.instance_initiated_shutdown_behavior
   placement_group                      = var.placement_group
   tenancy                              = var.tenancy

--- a/variables.tf
+++ b/variables.tf
@@ -305,6 +305,12 @@ variable "spot_valid_from" {
   default     = null
 }
 
+variable "disable_api_stop" {
+  description = "If true, enables EC2 Instance Stop Protection."
+  type        = bool
+  default     = null
+
+}
 variable "putin_khuylo" {
   description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.7"
+      version = ">= 4.20.0"
     }
   }
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -54,5 +54,6 @@ module "wrapper" {
   spot_instance_interruption_behavior  = try(each.value.spot_instance_interruption_behavior, var.defaults.spot_instance_interruption_behavior, null)
   spot_valid_until                     = try(each.value.spot_valid_until, var.defaults.spot_valid_until, null)
   spot_valid_from                      = try(each.value.spot_valid_from, var.defaults.spot_valid_from, null)
+  disable_api_stop                     = try(each.value.disable_api_stop, var.defaults.disable_api_stop, null)
   putin_khuylo                         = try(each.value.putin_khuylo, var.defaults.putin_khuylo, true)
 }


### PR DESCRIPTION
## Description
Added disable_api_stop action attribute to the ec2 instance resource - Supported in latest TF Provider release [4.20.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#4200-june-23-2022)

## Motivation and Context
 To prevent your instance from being accidentally stopped, you can enable stop protection for the instance. 


## Breaking Changes
No


## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

- [x] I have executed `pre-commit run -a` on my pull request

