### PR TITLE
feat: Add direct support for volume attachments

### DIFF
--- a/examples/volume-attachment/main.tf
+++ b/examples/volume-attachment/main.tf
@@ -72,13 +72,14 @@ module "ec2" {
   vpc_security_group_ids      = [module.security_group.security_group_id]
   associate_public_ip_address = true
 
-  tags = local.tags
-}
+  ebs_volume_attachments = [
+    {
+      device_name = "/dev/sdh"
+      volume_id   = aws_ebs_volume.this.id
+    }
+  ]
 
-resource "aws_volume_attachment" "this" {
-  device_name = "/dev/sdh"
-  volume_id   = aws_ebs_volume.this.id
-  instance_id = module.ec2.id
+  tags = local.tags
 }
 
 resource "aws_ebs_volume" "this" {

--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,19 @@ resource "aws_instance" "this" {
   volume_tags = var.enable_volume_tags ? merge({ "Name" = var.name }, var.volume_tags) : null
 }
 
+resource "aws_volume_attachment" "this" {
+  count = (!var.create_spot_instance ? length(var.ebs_volume_attachments) : 0)
+
+  device_name = var.ebs_volume_attachments[count.index].device_name
+  volume_id   = var.ebs_volume_attachments[count.index].volume_id
+  instance_id = aws_instance.this[0].id
+
+  # Not sure if I really need this
+  depends_on = [
+    aws_instance.this
+  ]
+}
+
 resource "aws_spot_instance_request" "this" {
   count = local.create && var.create_spot_instance ? 1 : 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -214,6 +214,12 @@ variable "user_data_replace_on_change" {
   default     = false
 }
 
+variable "ebs_volume_attachments" {
+  description = "A list of permanent EBS volumes to attach to the instance at launch time"
+  type        = list(map(string))
+  default     = []
+}
+
 variable "volume_tags" {
   description = "A mapping of tags to assign to the devices created by the instance at launch time"
   type        = map(string)


### PR DESCRIPTION
## Description
Add ebs_volume_attachments input variable and logic to automatically attach previously created volumes when starting instances.

## Motivation and Context
This change simplifies the creation of immutable servers when using Terragrunt with this module enabling the following configuration:

```
dependency "testdata_storage" {
    config_path = "../../storage/testdata"
}

inputs = {
    ami           = "ami-xxx"
    instance_type = "t3a.micro"

    ebs_volume_attachments = [
        {
            device_name ="/dev/xvdb"
            volume_id = dependency.testdata_storage.outputs.id
        }
    ]

    ...
}
```
## Breaking Changes
no

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
