### PR TITLE
feat: Set module shortname for wrapper pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,8 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each
+        args:
+          - '--args=--module-repo-shortname=ec2-instance'
       - id: terraform_validate
       - id: terraform_docs
         args:


### PR DESCRIPTION
## Description

Add `--module-repo-shortname` argument to `.pre-commit-config.yaml` to help in running `pre-commit` checks (primarily from a docker container with the repo mounted).

## Motivation and Context

Using the `pre-commit-terraform` docker container requires setting this variable to have wrappers/README.md properly generated.

Issue #295 

## Breaking Changes

No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
Not applicable
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
Not applicable, though I have verified that ec2_t2_unlimited still runs as expected
I have tested this change by running `pre-commit run -a` directly, as well as using the latest `pre-commit-terraform` docker container, and the output is as expected, including properly setting `source` in `wrappers/README.md`
- [x] I have executed `pre-commit run -a` on my pull request
