### PR TITLE
Change instance type to t3.micro to not trip users up on pricing and be friendly to free tier

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -33,7 +33,7 @@ module "ec2_complete" {
   name = local.name
 
   ami                         = data.aws_ami.amazon_linux.id
-  instance_type               = "c5.xlarge" # used to set core count below
+  instance_type               = "t3.micro" # used to set core count below
   availability_zone           = element(module.vpc.azs, 0)
   subnet_id                   = element(module.vpc.private_subnets, 0)
   vpc_security_group_ids      = [module.security_group.security_group_id]

--- a/examples/volume-attachment/main.tf
+++ b/examples/volume-attachment/main.tf
@@ -66,7 +66,7 @@ module "ec2" {
   name = local.name
 
   ami                         = data.aws_ami.amazon_linux.id
-  instance_type               = "c5.large"
+  instance_type               = "t3.micro"
   availability_zone           = local.availability_zone
   subnet_id                   = element(module.vpc.private_subnets, 0)
   vpc_security_group_ids      = [module.security_group.security_group_id]


### PR DESCRIPTION
## Description
Change instance type to t3.micro to not trip users up on pricing and be friendly to free tier

## Motivation and Context
Users of example terraform code could be new to AWS, and have no idea about the cost behind large instance types.

Using `c5.xlarge` and `c5.large` instance types can trip users up with unexpected costs. 

## Breaking Changes

Shouldn't break anything

## How Has This Been Tested?

It hasn't, insufficient changes needed for testing imo - but feel free to do it

