### PR TITLE
feat: Add support for `maintenance_options`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   TERRAFORM_DOCS_VERSION: v0.16.0
+  TFLINT_VERSION: v0.44.1
 
 jobs:
   collectInputs:
@@ -21,7 +22,7 @@ jobs:
 
       - name: Get root directories
         id: dirs
-        uses: clowdhaus/terraform-composite-actions/directories@v1.8.0
+        uses: clowdhaus/terraform-composite-actions/directories@v1.8.3
 
   preCommitMinVersions:
     name: Min TF pre-commit
@@ -36,24 +37,26 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.2.0
+        uses: clowdhaus/terraform-min-max@v1.2.4
         with:
           directory: ${{ matrix.directory }}
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
 
   preCommitMaxVersion:
@@ -69,18 +72,12 @@ jobs:
 
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.2.0
-
-      - name: Install hcledit (for terraform_wrapper_module_for_each hook)
-        shell: bash
-        run: |
-          curl -L "$(curl -s https://api.github.com/repos/minamijoyo/hcledit/releases/latest | grep -o -E -m 1 "https://.+?_linux_amd64.tar.gz")" > hcledit.tgz
-          sudo tar -xzf hcledit.tgz -C /usr/bin/ hcledit
-          rm -f hcledit.tgz 2> /dev/null
-          hcledit version
+        uses: clowdhaus/terraform-min-max@v1.2.4
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.0
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.8.3
         with:
           terraform-version: ${{ steps.minMax.outputs.maxVersion }}
+          tflint-version: ${{ env.TFLINT_VERSION }}
           terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}
+          install-hcledit: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+    rev: v1.77.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each
@@ -24,7 +24,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ No modules.
 | <a name="input_ami"></a> [ami](#input\_ami) | ID of AMI to use for the instance | `string` | `null` | no |
 | <a name="input_ami_ssm_parameter"></a> [ami\_ssm\_parameter](#input\_ami\_ssm\_parameter) | SSM parameter name for the AMI ID. For Amazon Linux AMI SSM parameters see [reference](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters-ami.html) | `string` | `"/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Whether to associate a public IP address with an instance in a VPC | `bool` | `null` | no |
-| <a name="input_auto_recovery"></a> [auto\_recovery](#input\_auto\_recovery) | Automatic recovery behavior of the Instance. Can be `default` or `disabled`. | `string` | `null` | no |
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | AZ to start the instance in | `string` | `null` | no |
 | <a name="input_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#input\_capacity\_reservation\_specification) | Describes an instance's Capacity Reservation targeting option | `any` | `{}` | no |
 | <a name="input_cpu_core_count"></a> [cpu\_core\_count](#input\_cpu\_core\_count) | Sets the number of CPU cores for an instance. | `number` | `null` | no |
@@ -233,6 +232,7 @@ No modules.
 | <a name="input_ipv6_addresses"></a> [ipv6\_addresses](#input\_ipv6\_addresses) | Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `null` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |
 | <a name="input_launch_template"></a> [launch\_template](#input\_launch\_template) | Specifies a Launch Template to configure the instance. Parameters configured on this resource will override the corresponding parameters in the Launch Template | `map(string)` | `null` | no |
+| <a name="input_maintenance_options"></a> [maintenance\_options](#input\_maintenance\_options) | The maintenance options for the instance | `any` | `{}` | no |
 | <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Customize the metadata options of the instance | `map(string)` | `{}` | no |
 | <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on EC2 instance created | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ No modules.
 | <a name="input_ami"></a> [ami](#input\_ami) | ID of AMI to use for the instance | `string` | `null` | no |
 | <a name="input_ami_ssm_parameter"></a> [ami\_ssm\_parameter](#input\_ami\_ssm\_parameter) | SSM parameter name for the AMI ID. For Amazon Linux AMI SSM parameters see [reference](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-public-parameters-ami.html) | `string` | `"/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"` | no |
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Whether to associate a public IP address with an instance in a VPC | `bool` | `null` | no |
+| <a name="input_auto_recovery"></a> [auto\_recovery](#input\_auto\_recovery) | Automatic recovery behavior of the Instance. Can be `default` or `disabled`. | `string` | `null` | no |
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | AZ to start the instance in | `string` | `null` | no |
 | <a name="input_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#input\_capacity\_reservation\_specification) | Describes an instance's Capacity Reservation targeting option | `any` | `{}` | no |
 | <a name="input_cpu_core_count"></a> [cpu\_core\_count](#input\_cpu\_core\_count) | Sets the number of CPU cores for an instance. | `number` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -129,6 +129,8 @@ module "ec2_t2_unlimited" {
   vpc_security_group_ids      = [module.security_group.security_group_id]
   associate_public_ip_address = true
 
+  auto_recovery = "disabled"
+
   tags = local.tags
 }
 
@@ -232,7 +234,6 @@ module "ec2_spot_instance" {
 
   cpu_core_count       = 2 # default 4
   cpu_threads_per_core = 1 # default 2
-
 
   enable_volume_tags = false
   root_block_device = [

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -129,7 +129,9 @@ module "ec2_t2_unlimited" {
   vpc_security_group_ids      = [module.security_group.security_group_id]
   associate_public_ip_address = true
 
-  auto_recovery = "disabled"
+  maintenance_options = {
+    auto_recovery = "default"
+  }
 
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -128,9 +128,9 @@ resource "aws_instance" "this" {
   }
 
   dynamic "maintenance_options" {
-    for_each = var.auto_recovery != null ? [var.auto_recovery] : []
+    for_each = length(var.maintenance_options) > 0 ? [var.maintenance_options] : []
     content {
-      auto_recovery = var.auto_recovery
+      auto_recovery = try(maintenance_options.value.auto_recovery, null)
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,13 @@ resource "aws_instance" "this" {
     }
   }
 
+  dynamic "maintenance_options" {
+    for_each = var.auto_recovery != null ? [var.auto_recovery] : []
+    content {
+      auto_recovery = var.auto_recovery
+    }
+  }
+
   enclave_options {
     enabled = var.enclave_options_enabled
   }

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "associate_public_ip_address" {
   default     = null
 }
 
+variable "auto_recovery" {
+  description = "Automatic recovery behavior of the Instance. Can be `default` or `disabled`."
+  type        = string
+  default     = null
+}
+
 variable "availability_zone" {
   description = "AZ to start the instance in"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -28,10 +28,10 @@ variable "associate_public_ip_address" {
   default     = null
 }
 
-variable "auto_recovery" {
-  description = "Automatic recovery behavior of the Instance. Can be `default` or `disabled`."
-  type        = string
-  default     = null
+variable "maintenance_options" {
+  description = "The maintenance options for the instance"
+  type        = any
+  default     = {}
 }
 
 variable "availability_zone" {

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -8,7 +8,7 @@ module "wrapper" {
   ami_ssm_parameter                    = try(each.value.ami_ssm_parameter, var.defaults.ami_ssm_parameter, "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2")
   ami                                  = try(each.value.ami, var.defaults.ami, null)
   associate_public_ip_address          = try(each.value.associate_public_ip_address, var.defaults.associate_public_ip_address, null)
-  auto_recovery                        = try(each.value.auto_recovery, var.defaults.auto_recovery, null)
+  maintenance_options                  = try(each.value.maintenance_options, var.defaults.maintenance_options, {})
   availability_zone                    = try(each.value.availability_zone, var.defaults.availability_zone, null)
   capacity_reservation_specification   = try(each.value.capacity_reservation_specification, var.defaults.capacity_reservation_specification, {})
   cpu_credits                          = try(each.value.cpu_credits, var.defaults.cpu_credits, null)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -8,6 +8,7 @@ module "wrapper" {
   ami_ssm_parameter                    = try(each.value.ami_ssm_parameter, var.defaults.ami_ssm_parameter, "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2")
   ami                                  = try(each.value.ami, var.defaults.ami, null)
   associate_public_ip_address          = try(each.value.associate_public_ip_address, var.defaults.associate_public_ip_address, null)
+  auto_recovery                        = try(each.value.auto_recovery, var.defaults.auto_recovery, null)
   availability_zone                    = try(each.value.availability_zone, var.defaults.availability_zone, null)
   capacity_reservation_specification   = try(each.value.capacity_reservation_specification, var.defaults.capacity_reservation_specification, {})
   cpu_credits                          = try(each.value.cpu_credits, var.defaults.cpu_credits, null)


### PR DESCRIPTION
## Description
Adding `auto_recovery` option to toggle between `default` and `disabled`. This argument is computed if not configured. 
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-recover.html 

## Motivation and Context
- Resolves #310

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
