### PR TITLE
fix: Marked AMI id as nonsensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_ami"></a> [ami](#output\_ami) | AMI ID that was used to create the instance. |
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the instance |
 | <a name="output_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#output\_capacity\_reservation\_specification) | Capacity reservation specification of the instance |
 | <a name="output_iam_instance_profile_arn"></a> [iam\_instance\_profile\_arn](#output\_iam\_instance\_profile\_arn) | ARN assigned by AWS to the instance profile |

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ data "aws_ssm_parameter" "this" {
 resource "aws_instance" "this" {
   count = local.create && !var.create_spot_instance ? 1 : 0
 
-  ami                  = try(coalesce(var.ami, data.aws_ssm_parameter.this[0].value), null)
+  ami                  = nonsensitive(try(coalesce(var.ami, data.aws_ssm_parameter.this[0].value), null))
   instance_type        = var.instance_type
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core
@@ -167,7 +167,7 @@ resource "aws_instance" "this" {
 resource "aws_spot_instance_request" "this" {
   count = local.create && var.create_spot_instance ? 1 : 0
 
-  ami                  = try(coalesce(var.ami, data.aws_ssm_parameter.this[0].value), null)
+  ami                  = nonsensitive(try(coalesce(var.ami, data.aws_ssm_parameter.this[0].value), null))
   instance_type        = var.instance_type
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ data "aws_ssm_parameter" "this" {
 resource "aws_instance" "this" {
   count = local.create && !var.create_spot_instance ? 1 : 0
 
-  ami                  = nonsensitive(try(coalesce(var.ami, data.aws_ssm_parameter.this[0].value), null))
+  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
   instance_type        = var.instance_type
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core
@@ -167,7 +167,7 @@ resource "aws_instance" "this" {
 resource "aws_spot_instance_request" "this" {
   count = local.create && var.create_spot_instance ? 1 : 0
 
-  ami                  = nonsensitive(try(coalesce(var.ami, data.aws_ssm_parameter.this[0].value), null))
+  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
   instance_type        = var.instance_type
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,6 +78,11 @@ output "spot_instance_id" {
   value       = try(aws_spot_instance_request.this[0].spot_instance_id, "")
 }
 
+output "ami" {
+  description = "AMI ID that was used to create the instance."
+  value       = try(aws_instance.this[0].ami, aws_spot_instance_request.this[0].ami, "")
+}
+
 ################################################################################
 # IAM Role / Instance Profile
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

When running `terraform plan` - the `ami` is hidden and marked as sensitive. This happens whether or not an AMI Id is provided or `ami_ssm_parameter` is used. This is because `aws_ssm_parameter`value is by default a sensitive value.

Example:
```
 # module.ec2.aws_instance.this[0] will be created
  + resource "aws_instance" "this" {
      + ami                                  = (sensitive value)
      + arn                                  = (known after apply)
      + associate_public_ip_address          = true
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When running `terraform plan`, it would be nice to know the AMI ID, especially when a `replace` is triggered. If I am replacing the instance because of an AMI change, I want to make sure the correct AMI ID is being used. This is especially helpful when using `ami_ssm_parameter`, to make sure the correct paramter value is used.

I also think it might be useful to include the AMI as the output. When using `ami_ssm_parameter`, the actual AMI Id is not obvious, so including it in the output makes it easy to identify which AMI was used from the parameter store.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

N/A

## How Has This Been Tested?
- (n/a) I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

Ran `terraform plan` after making the change

```
 # module.ec2_t3_unlimited.aws_instance.this[0] will be created
  + resource "aws_instance" "this" {
      + ami                                  = "ami-05247819264504af0"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = true
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
```