### PR TITLE
feat: Add unique tags to EBS block devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ No modules.
 | <a name="input_create_spot_instance"></a> [create\_spot\_instance](#input\_create\_spot\_instance) | Depicts if the instance is a spot instance | `bool` | `false` | no |
 | <a name="input_disable_api_stop"></a> [disable\_api\_stop](#input\_disable\_api\_stop) | If true, enables EC2 Instance Stop Protection. | `bool` | `null` | no |
 | <a name="input_disable_api_termination"></a> [disable\_api\_termination](#input\_disable\_api\_termination) | If true, enables EC2 Instance Termination Protection | `bool` | `null` | no |
-| <a name="input_ebs_block_device"></a> [ebs\_block\_device](#input\_ebs\_block\_device) | Additional EBS block devices to attach to the instance | `list(map(string))` | `[]` | no |
+| <a name="input_ebs_block_device"></a> [ebs\_block\_device](#input\_ebs\_block\_device) | Additional EBS block devices to attach to the instance | `list(any)` | `[]` | no |
 | <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | If true, the launched EC2 instance will be EBS-optimized | `bool` | `null` | no |
 | <a name="input_enable_volume_tags"></a> [enable\_volume\_tags](#input\_enable\_volume\_tags) | Whether to enable volume tags (if enabled it conflicts with root\_block\_device tags) | `bool` | `true` | no |
 | <a name="input_enclave_options_enabled"></a> [enclave\_options\_enabled](#input\_enclave\_options\_enabled) | Whether Nitro Enclaves will be enabled on the instance. Defaults to `false` | `bool` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -78,6 +78,9 @@ module "ec2_complete" {
       throughput  = 200
       encrypted   = true
       kms_key_id  = aws_kms_key.this.arn
+      tags = {
+        MountPoint = "/mnt/data"
+      }
     }
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,7 @@ resource "aws_instance" "this" {
       volume_size           = lookup(ebs_block_device.value, "volume_size", null)
       volume_type           = lookup(ebs_block_device.value, "volume_type", null)
       throughput            = lookup(ebs_block_device.value, "throughput", null)
+      tags                  = lookup(ebs_block_device.value, "tags", null)
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -60,7 +60,7 @@ variable "disable_api_termination" {
 
 variable "ebs_block_device" {
   description = "Additional EBS block devices to attach to the instance"
-  type        = list(map(string))
+  type        = list(any)
   default     = []
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added `tags` to the `ebs_block_device` dynamic block.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The change is not required, however it enables users to add unique tags per block device as opposed to just the general tags applied via `var.volume_tags`.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This does not break backwards compatibility - it is purely additive with no additional variables.

## How Has This Been Tested?
- [ X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
Used the docker version and all tests passed except the `Terraform wrapper with for_each in module`. The linter changed the URL in the source lines, replacing every occurrence of `ec2-instance` with `lint`, so I did not commit those changes.