### PR TITLE
feat: Implementation of the cpu_options block and addition of support for AMD SEV-SNP

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,8 @@ No modules.
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Whether to associate a public IP address with an instance in a VPC | `bool` | `null` | no |
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | AZ to start the instance in | `string` | `null` | no |
 | <a name="input_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#input\_capacity\_reservation\_specification) | Describes an instance's Capacity Reservation targeting option | `any` | `{}` | no |
-| <a name="input_cpu_core_count"></a> [cpu\_core\_count](#input\_cpu\_core\_count) | Sets the number of CPU cores for an instance | `number` | `null` | no |
 | <a name="input_cpu_credits"></a> [cpu\_credits](#input\_cpu\_credits) | The credit option for CPU usage (unlimited or standard) | `string` | `null` | no |
 | <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | Defines CPU options to apply to the instance at launch time. | `any` | `{}` | no |
-| <a name="input_cpu_threads_per_core"></a> [cpu\_threads\_per\_core](#input\_cpu\_threads\_per\_core) | Sets the number of CPU threads per core for an instance (has no effect unless cpu\_core\_count is also set) | `number` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create an instance | `bool` | `true` | no |
 | <a name="input_create_iam_instance_profile"></a> [create\_iam\_instance\_profile](#input\_create\_iam\_instance\_profile) | Determines whether an IAM instance profile is created or to use an existing IAM instance profile | `bool` | `false` | no |
 | <a name="input_create_spot_instance"></a> [create\_spot\_instance](#input\_create\_spot\_instance) | Depicts if the instance is a spot instance | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ The following combinations are supported to conditionally create resources:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.20 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.20 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66 |
 
 ## Modules
 
@@ -199,6 +199,7 @@ No modules.
 | <a name="input_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#input\_capacity\_reservation\_specification) | Describes an instance's Capacity Reservation targeting option | `any` | `{}` | no |
 | <a name="input_cpu_core_count"></a> [cpu\_core\_count](#input\_cpu\_core\_count) | Sets the number of CPU cores for an instance | `number` | `null` | no |
 | <a name="input_cpu_credits"></a> [cpu\_credits](#input\_cpu\_credits) | The credit option for CPU usage (unlimited or standard) | `string` | `null` | no |
+| <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | Defines CPU options to apply to the instance at launch time. | `any` | `{}` | no |
 | <a name="input_cpu_threads_per_core"></a> [cpu\_threads\_per\_core](#input\_cpu\_threads\_per\_core) | Sets the number of CPU threads per core for an instance (has no effect unless cpu\_core\_count is also set) | `number` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create an instance | `bool` | `true` | no |
 | <a name="input_create_iam_instance_profile"></a> [create\_iam\_instance\_profile](#input\_create\_iam\_instance\_profile) | Determines whether an IAM instance profile is created or to use an existing IAM instance profile | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -197,8 +197,10 @@ No modules.
 | <a name="input_associate_public_ip_address"></a> [associate\_public\_ip\_address](#input\_associate\_public\_ip\_address) | Whether to associate a public IP address with an instance in a VPC | `bool` | `null` | no |
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | AZ to start the instance in | `string` | `null` | no |
 | <a name="input_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#input\_capacity\_reservation\_specification) | Describes an instance's Capacity Reservation targeting option | `any` | `{}` | no |
+| <a name="input_cpu_core_count"></a> [cpu\_core\_count](#input\_cpu\_core\_count) | Sets the number of CPU cores for an instance | `number` | `null` | no |
 | <a name="input_cpu_credits"></a> [cpu\_credits](#input\_cpu\_credits) | The credit option for CPU usage (unlimited or standard) | `string` | `null` | no |
 | <a name="input_cpu_options"></a> [cpu\_options](#input\_cpu\_options) | Defines CPU options to apply to the instance at launch time. | `any` | `{}` | no |
+| <a name="input_cpu_threads_per_core"></a> [cpu\_threads\_per\_core](#input\_cpu\_threads\_per\_core) | Sets the number of CPU threads per core for an instance (has no effect unless cpu\_core\_count is also set) | `number` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create an instance | `bool` | `true` | no |
 | <a name="input_create_iam_instance_profile"></a> [create\_iam\_instance\_profile](#input\_create\_iam\_instance\_profile) | Determines whether an IAM instance profile is created or to use an existing IAM instance profile | `bool` | `false` | no |
 | <a name="input_create_spot_instance"></a> [create\_spot\_instance](#input\_create\_spot\_instance) | Depicts if the instance is a spot instance | `bool` | `false` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,19 +20,20 @@ Note that this example may create resources which can cost money. Run `terraform
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.20 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.66 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.20 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.66 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_ec2_complete"></a> [ec2\_complete](#module\_ec2\_complete) | ../../ | n/a |
+| <a name="module_ec2_cpu_options"></a> [ec2\_cpu\_options](#module\_ec2\_cpu\_options) | ../../ | n/a |
 | <a name="module_ec2_disabled"></a> [ec2\_disabled](#module\_ec2\_disabled) | ../../ | n/a |
 | <a name="module_ec2_metadata_options"></a> [ec2\_metadata\_options](#module\_ec2\_metadata\_options) | ../../ | n/a |
 | <a name="module_ec2_multiple"></a> [ec2\_multiple](#module\_ec2\_multiple) | ../../ | n/a |
@@ -55,6 +56,7 @@ Note that this example may create resources which can cost money. Run `terraform
 | [aws_network_interface.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface) | resource |
 | [aws_placement_group.web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/placement_group) | resource |
 | [aws_ami.amazon_linux](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ami.amazon_linux_23](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -55,7 +55,7 @@ module "ec2_complete" {
   user_data_replace_on_change = true
 
   cpu_options = {
-    core_count = 2
+    core_count       = 2
     threads_per_core = 1
   }
   enable_volume_tags = false
@@ -246,7 +246,7 @@ module "ec2_spot_instance" {
   user_data_base64 = base64encode(local.user_data)
 
   cpu_options = {
-    core_count = 2
+    core_count       = 2
     threads_per_core = 1
   }
 
@@ -364,9 +364,9 @@ module "ec2_cpu_options" {
   user_data_replace_on_change = true
 
   cpu_options = {
-    core_count = 2
+    core_count       = 2
     threads_per_core = 1
-    amd_sev_snp = "enabled"
+    amd_sev_snp      = "enabled"
   }
   enable_volume_tags = false
   root_block_device = [

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -54,9 +54,10 @@ module "ec2_complete" {
   user_data_base64            = base64encode(local.user_data)
   user_data_replace_on_change = true
 
-  cpu_core_count       = 2 # default 4
-  cpu_threads_per_core = 1 # default 2
-
+  cpu_options = {
+    core_count = 2
+    threads_per_core = 1
+  }
   enable_volume_tags = false
   root_block_device = [
     {
@@ -244,8 +245,10 @@ module "ec2_spot_instance" {
 
   user_data_base64 = base64encode(local.user_data)
 
-  cpu_core_count       = 2 # default 4
-  cpu_threads_per_core = 1 # default 2
+  cpu_options = {
+    core_count = 2
+    threads_per_core = 1
+  }
 
   enable_volume_tags = false
   root_block_device = [
@@ -335,6 +338,72 @@ resource "aws_ec2_capacity_reservation" "targeted" {
 }
 
 ################################################################################
+# EC2 Module - CPU Options
+################################################################################
+module "ec2_cpu_options" {
+  source = "../../"
+
+  name = "${local.name}-cpu-options"
+
+  ami                         = data.aws_ami.amazon_linux_23.id
+  instance_type               = "c6a.xlarge" # used to set core count below and test amd_sev_snp attribute
+  availability_zone           = element(module.vpc.azs, 0)
+  subnet_id                   = element(module.vpc.private_subnets, 0)
+  vpc_security_group_ids      = [module.security_group.security_group_id]
+  placement_group             = aws_placement_group.web.id
+  associate_public_ip_address = true
+  disable_api_stop            = false
+
+  create_iam_instance_profile = true
+  iam_role_description        = "IAM role for EC2 instance"
+  iam_role_policies = {
+    AdministratorAccess = "arn:aws:iam::aws:policy/AdministratorAccess"
+  }
+
+  user_data_base64            = base64encode(local.user_data)
+  user_data_replace_on_change = true
+
+  cpu_options = {
+    core_count = 2
+    threads_per_core = 1
+    amd_sev_snp = "enabled"
+  }
+  enable_volume_tags = false
+  root_block_device = [
+    {
+      encrypted   = true
+      volume_type = "gp3"
+      throughput  = 200
+      volume_size = 50
+      tags = {
+        Name = "my-root-block"
+      }
+    },
+  ]
+
+  ebs_block_device = [
+    {
+      device_name = "/dev/sdf"
+      volume_type = "gp3"
+      volume_size = 5
+      throughput  = 200
+      encrypted   = true
+      kms_key_id  = aws_kms_key.this.arn
+      tags = {
+        MountPoint = "/mnt/data"
+      }
+    }
+  ]
+
+  tags = merge(
+    local.tags,
+    {
+      Name = "${local.name}-cpu-options"
+    }
+  )
+}
+
+################################################################################
 # Supporting Resources
 ################################################################################
 
@@ -359,6 +428,16 @@ data "aws_ami" "amazon_linux" {
   filter {
     name   = "name"
     values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+data "aws_ami" "amazon_linux_23" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023*-x86_64"]
   }
 }
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20"
+      version = ">= 4.66"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -189,6 +189,8 @@ resource "aws_instance" "ignore_ami" {
 
   ami           = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
   instance_type = var.instance_type
+  cpu_core_count       = var.cpu_core_count
+  cpu_threads_per_core = var.cpu_threads_per_core
   hibernation   = var.hibernation
 
   user_data                   = var.user_data
@@ -361,6 +363,8 @@ resource "aws_spot_instance_request" "this" {
 
   ami           = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
   instance_type = var.instance_type
+  cpu_core_count       = var.cpu_core_count
+  cpu_threads_per_core = var.cpu_threads_per_core
   hibernation   = var.hibernation
 
   user_data                   = var.user_data

--- a/main.tf
+++ b/main.tf
@@ -21,8 +21,6 @@ resource "aws_instance" "this" {
 
   ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
   instance_type        = var.instance_type
-  cpu_core_count       = var.cpu_core_count
-  cpu_threads_per_core = var.cpu_threads_per_core
   hibernation          = var.hibernation
 
   user_data                   = var.user_data
@@ -189,8 +187,6 @@ resource "aws_instance" "ignore_ami" {
 
   ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
   instance_type        = var.instance_type
-  cpu_core_count       = var.cpu_core_count
-  cpu_threads_per_core = var.cpu_threads_per_core
   hibernation          = var.hibernation
 
   user_data                   = var.user_data
@@ -213,6 +209,16 @@ resource "aws_instance" "ignore_ami" {
   ipv6_addresses              = var.ipv6_addresses
 
   ebs_optimized = var.ebs_optimized
+
+  dynamic "cpu_options" {
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
+
+    content {
+      core_count       = try(cpu_options.value.core_count, null)
+      threads_per_core = try(cpu_options.value.threads_per_core, null)
+      amd_sev_snp      = try(cpu_options.value.amd_sev_snp, null)
+    }
+  }
 
   dynamic "capacity_reservation_specification" {
     for_each = length(var.capacity_reservation_specification) > 0 ? [var.capacity_reservation_specification] : []
@@ -353,8 +359,6 @@ resource "aws_spot_instance_request" "this" {
 
   ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
   instance_type        = var.instance_type
-  cpu_core_count       = var.cpu_core_count
-  cpu_threads_per_core = var.cpu_threads_per_core
   hibernation          = var.hibernation
 
   user_data                   = var.user_data
@@ -388,6 +392,16 @@ resource "aws_spot_instance_request" "this" {
   valid_until                    = var.spot_valid_until
   valid_from                     = var.spot_valid_from
   # End spot request specific attributes
+
+  dynamic "cpu_options" {
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
+
+    content {
+      core_count       = try(cpu_options.value.core_count, null)
+      threads_per_core = try(cpu_options.value.threads_per_core, null)
+      amd_sev_snp      = try(cpu_options.value.amd_sev_snp, null)
+    }
+  }
 
   dynamic "capacity_reservation_specification" {
     for_each = length(var.capacity_reservation_specification) > 0 ? [var.capacity_reservation_specification] : []

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,16 @@ resource "aws_instance" "this" {
 
   ebs_optimized = var.ebs_optimized
 
+  dynamic "cpu_options" {
+    for_each = length(var.cpu_options) > 0 ? [var.cpu_options] : []
+
+    content {
+      core_count       = try(cpu_options.value.core_count, null)
+      threads_per_core = try(cpu_options.value.threads_per_core, null)
+      amd_sev_snp      = try(cpu_options.value.amd_sev_snp, null)
+    }
+  }
+
   dynamic "capacity_reservation_specification" {
     for_each = length(var.capacity_reservation_specification) > 0 ? [var.capacity_reservation_specification] : []
 

--- a/main.tf
+++ b/main.tf
@@ -19,9 +19,11 @@ data "aws_ssm_parameter" "this" {
 resource "aws_instance" "this" {
   count = local.create && !var.ignore_ami_changes && !var.create_spot_instance ? 1 : 0
 
-  ami           = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
-  instance_type = var.instance_type
-  hibernation   = var.hibernation
+  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
+  instance_type        = var.instance_type
+  cpu_core_count       = var.cpu_core_count
+  cpu_threads_per_core = var.cpu_threads_per_core
+  hibernation          = var.hibernation
 
   user_data                   = var.user_data
   user_data_base64            = var.user_data_base64

--- a/main.tf
+++ b/main.tf
@@ -187,11 +187,11 @@ resource "aws_instance" "this" {
 resource "aws_instance" "ignore_ami" {
   count = local.create && var.ignore_ami_changes && !var.create_spot_instance ? 1 : 0
 
-  ami           = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
-  instance_type = var.instance_type
+  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
+  instance_type        = var.instance_type
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core
-  hibernation   = var.hibernation
+  hibernation          = var.hibernation
 
   user_data                   = var.user_data
   user_data_base64            = var.user_data_base64
@@ -361,11 +361,11 @@ resource "aws_instance" "ignore_ami" {
 resource "aws_spot_instance_request" "this" {
   count = local.create && var.create_spot_instance ? 1 : 0
 
-  ami           = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
-  instance_type = var.instance_type
+  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
+  instance_type        = var.instance_type
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core
-  hibernation   = var.hibernation
+  hibernation          = var.hibernation
 
   user_data                   = var.user_data
   user_data_base64            = var.user_data_base64

--- a/main.tf
+++ b/main.tf
@@ -19,9 +19,9 @@ data "aws_ssm_parameter" "this" {
 resource "aws_instance" "this" {
   count = local.create && !var.ignore_ami_changes && !var.create_spot_instance ? 1 : 0
 
-  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
-  instance_type        = var.instance_type
-  hibernation          = var.hibernation
+  ami           = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
+  instance_type = var.instance_type
+  hibernation   = var.hibernation
 
   user_data                   = var.user_data
   user_data_base64            = var.user_data_base64
@@ -185,9 +185,9 @@ resource "aws_instance" "this" {
 resource "aws_instance" "ignore_ami" {
   count = local.create && var.ignore_ami_changes && !var.create_spot_instance ? 1 : 0
 
-  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
-  instance_type        = var.instance_type
-  hibernation          = var.hibernation
+  ami           = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
+  instance_type = var.instance_type
+  hibernation   = var.hibernation
 
   user_data                   = var.user_data
   user_data_base64            = var.user_data_base64
@@ -357,9 +357,9 @@ resource "aws_instance" "ignore_ami" {
 resource "aws_spot_instance_request" "this" {
   count = local.create && var.create_spot_instance ? 1 : 0
 
-  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
-  instance_type        = var.instance_type
-  hibernation          = var.hibernation
+  ami           = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
+  instance_type = var.instance_type
+  hibernation   = var.hibernation
 
   user_data                   = var.user_data
   user_data_base64            = var.user_data_base64

--- a/variables.tf
+++ b/variables.tf
@@ -260,6 +260,12 @@ variable "timeouts" {
   default     = {}
 }
 
+variable "cpu_options" {
+  description = "Defines CPU options to apply to the instance at launch time."
+  type        = any
+  default     = {}
+}
+
 variable "cpu_core_count" {
   description = "Sets the number of CPU cores for an instance" # This option is only supported on creation of instance type that support CPU Options https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html#cpu-options-supported-instances-values
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -266,6 +266,18 @@ variable "cpu_options" {
   default     = {}
 }
 
+variable "cpu_core_count" {
+  description = "Sets the number of CPU cores for an instance" # This option is only supported on creation of instance type that support CPU Options https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html#cpu-options-supported-instances-values
+  type        = number
+  default     = null
+}
+
+variable "cpu_threads_per_core" {
+  description = "Sets the number of CPU threads per core for an instance (has no effect unless cpu_core_count is also set)"
+  type        = number
+  default     = null
+}
+
 # Spot instance request
 variable "create_spot_instance" {
   description = "Depicts if the instance is a spot instance"

--- a/variables.tf
+++ b/variables.tf
@@ -266,18 +266,6 @@ variable "cpu_options" {
   default     = {}
 }
 
-variable "cpu_core_count" {
-  description = "Sets the number of CPU cores for an instance" # This option is only supported on creation of instance type that support CPU Options https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html#cpu-options-supported-instances-values
-  type        = number
-  default     = null
-}
-
-variable "cpu_threads_per_core" {
-  description = "Sets the number of CPU threads per core for an instance (has no effect unless cpu_core_count is also set)"
-  type        = number
-  default     = null
-}
-
 # Spot instance request
 variable "create_spot_instance" {
   description = "Depicts if the instance is a spot instance"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20"
+      version = ">= 4.66"
     }
   }
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -51,6 +51,8 @@ module "wrapper" {
   vpc_security_group_ids              = try(each.value.vpc_security_group_ids, var.defaults.vpc_security_group_ids, null)
   timeouts                            = try(each.value.timeouts, var.defaults.timeouts, {})
   cpu_options                         = try(each.value.cpu_options, var.defaults.cpu_options, {})
+  cpu_core_count                      = try(each.value.cpu_core_count, var.defaults.cpu_core_count, null)
+  cpu_threads_per_core                = try(each.value.cpu_threads_per_core, var.defaults.cpu_threads_per_core, null)
   create_spot_instance                = try(each.value.create_spot_instance, var.defaults.create_spot_instance, false)
   spot_price                          = try(each.value.spot_price, var.defaults.spot_price, null)
   spot_wait_for_fulfillment           = try(each.value.spot_wait_for_fulfillment, var.defaults.spot_wait_for_fulfillment, null)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -51,8 +51,6 @@ module "wrapper" {
   vpc_security_group_ids              = try(each.value.vpc_security_group_ids, var.defaults.vpc_security_group_ids, null)
   timeouts                            = try(each.value.timeouts, var.defaults.timeouts, {})
   cpu_options                         = try(each.value.cpu_options, var.defaults.cpu_options, {})
-  cpu_core_count                      = try(each.value.cpu_core_count, var.defaults.cpu_core_count, null)
-  cpu_threads_per_core                = try(each.value.cpu_threads_per_core, var.defaults.cpu_threads_per_core, null)
   create_spot_instance                = try(each.value.create_spot_instance, var.defaults.create_spot_instance, false)
   spot_price                          = try(each.value.spot_price, var.defaults.spot_price, null)
   spot_wait_for_fulfillment           = try(each.value.spot_wait_for_fulfillment, var.defaults.spot_wait_for_fulfillment, null)

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -50,6 +50,7 @@ module "wrapper" {
   enable_volume_tags                  = try(each.value.enable_volume_tags, var.defaults.enable_volume_tags, true)
   vpc_security_group_ids              = try(each.value.vpc_security_group_ids, var.defaults.vpc_security_group_ids, null)
   timeouts                            = try(each.value.timeouts, var.defaults.timeouts, {})
+  cpu_options                         = try(each.value.cpu_options, var.defaults.cpu_options, {})
   cpu_core_count                      = try(each.value.cpu_core_count, var.defaults.cpu_core_count, null)
   cpu_threads_per_core                = try(each.value.cpu_threads_per_core, var.defaults.cpu_threads_per_core, null)
   create_spot_instance                = try(each.value.create_spot_instance, var.defaults.create_spot_instance, false)


### PR DESCRIPTION
## Description
I have implemented the fix for the deprecation warning of cpu_core_count and cpu_threads_per_core attributes. Those can now be specified using the cpu_options block.

In addition, this PR adds the support for AMD SEV-SNP which is also a new attribute that can be set via the cpu_options block.

## Motivation and Context
- Resolves #332 
- Resolves #333 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
Yes, customers can no longer use the  cpu_core_count and cpu_threads_per_core variables anymore.
Those have been removed in favor of a new variable cpu_options that can be used as below:

```
cpu_options = {
    core_count       = 2
    threads_per_core = 1
}
```

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
