### PR TITLE
fix: Mark the output of the AMI ID as nonsensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -146,9 +146,9 @@ output "spot_instance_id" {
 output "ami" {
   description = "AMI ID that was used to create the instance"
   value = try(
-    aws_instance.this[0].ami,
-    aws_instance.ignore_ami[0].ami,
-    aws_spot_instance_request.this[0].ami,
+    nonsensitive(aws_instance.this[0].ami),
+    nonsensitive(aws_instance.ignore_ami[0].ami),
+    nonsensitive(aws_spot_instance_request.this[0].ami),
     null,
   )
 }


### PR DESCRIPTION
## Description

Using the latest version of this Terraform module and the AWS provider causes the following error message. 

```
dhoppe at mac-mini in eu-west-1/tfs4jira/ec2 on  main
❯ terragrunt plan
data.aws_partition.current: Reading...
data.aws_ssm_parameter.this[0]: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_iam_policy_document.assume_role_policy[0]: Reading...
data.aws_iam_policy_document.assume_role_policy[0]: Read complete after 0s [id=1256122602]
aws_iam_role.this[0]: Refreshing state... [id=tfs4jira-ec2-dev]
data.aws_ssm_parameter.this[0]: Read complete after 0s [id=/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2]
aws_iam_role_policy_attachment.this["CloudWatchAgentServerPolicy"]: Refreshing state... [id=tfs4jira-ec2-dev-20230321143309684800000004]
aws_iam_role_policy_attachment.this["AmazonSSMDirectoryServiceAccess"]: Refreshing state... [id=tfs4jira-ec2-dev-20230321143309486800000002]
aws_iam_role_policy_attachment.this["TFS4JiraKMSDecrypt"]: Refreshing state... [id=tfs4jira-ec2-dev-20230321165022847500000001]
aws_iam_role_policy_attachment.this["AmazonSSMManagedInstanceCore"]: Refreshing state... [id=tfs4jira-ec2-dev-20230321143309636100000003]
aws_iam_role_policy_attachment.this["AmazonEC2ReadOnlyAccess"]: Refreshing state... [id=tfs4jira-ec2-dev-20230321143309341500000001]
aws_iam_instance_profile.this[0]: Refreshing state... [id=tfs4jira-ec2-dev]
aws_instance.ignore_ami[0]: Refreshing state... [id=i-03962882275b387bf]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Output refers to sensitive values
│
│   on outputs.tf line 146:
│  146: output "ami" {
│
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
ERRO[0010] Terraform invocation failed in /Users/dhoppe/Documents/customers/REDACTED/terragrunt-aws-atlassian/stacks/dev/eu-west-1/tfs4jira/ec2/.terragrunt-cache/IjGgvqSySUKtu-5Pyf61D24eh6U/pfgqyj3TsBEWff7a1El6tYu6LEE  prefix=[/Users/dhoppe/Documents/customers/REDACTED/terragrunt-aws-atlassian/stacks/dev/eu-west-1/tfs4jira/ec2]
ERRO[0010] 1 error occurred:
	* [/Users/dhoppe/Documents/customers/REDACTED/terragrunt-aws-atlassian/stacks/dev/eu-west-1/tfs4jira/ec2/.terragrunt-cache/IjGgvqSySUKtu-5Pyf61D24eh6U/pfgqyj3TsBEWff7a1El6tYu6LEE] exit status 1
```

## Motivation and Context

I would like to be able to use this Terraform module again without causing any error messages. Since the AMI ID is not sensitive anyway, this change should not be a problem. 

## Breaking Changes
This change does not break backwards compatibility with the current major version.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
