### PR TITLE
feat: Add `availability_zone` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ No modules.
 |------|-------------|
 | <a name="output_ami"></a> [ami](#output\_ami) | AMI ID that was used to create the instance |
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the instance |
+| <a name="output_availability_zone"></a> [availability\_zone](#output\_availability\_zone) | The availability zone of the created instance |
 | <a name="output_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#output\_capacity\_reservation\_specification) | Capacity reservation specification of the instance |
 | <a name="output_ebs_block_device"></a> [ebs\_block\_device](#output\_ebs\_block\_device) | EBS block device information |
 | <a name="output_ephemeral_block_device"></a> [ephemeral\_block\_device](#output\_ephemeral\_block\_device) | Ephemeral block device information |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -69,6 +69,7 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | <a name="output_ec2_complete_arn"></a> [ec2\_complete\_arn](#output\_ec2\_complete\_arn) | The ARN of the instance |
+| <a name="output_ec2_complete_availability_zone"></a> [ec2\_complete\_availability\_zone](#output\_ec2\_complete\_availability\_zone) | The availability zone of the created instance |
 | <a name="output_ec2_complete_capacity_reservation_specification"></a> [ec2\_complete\_capacity\_reservation\_specification](#output\_ec2\_complete\_capacity\_reservation\_specification) | Capacity reservation specification of the instance |
 | <a name="output_ec2_complete_ebs_block_device"></a> [ec2\_complete\_ebs\_block\_device](#output\_ec2\_complete\_ebs\_block\_device) | EBS block device information |
 | <a name="output_ec2_complete_ephemeral_block_device"></a> [ec2\_complete\_ephemeral\_block\_device](#output\_ec2\_complete\_ephemeral\_block\_device) | Ephemeral block device information |
@@ -98,6 +99,7 @@ No inputs.
 | <a name="output_ec2_spot_instance_public_ip"></a> [ec2\_spot\_instance\_public\_ip](#output\_ec2\_spot\_instance\_public\_ip) | The public IP address assigned to the instance, if applicable. NOTE: If you are using an aws\_eip with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached |
 | <a name="output_ec2_spot_instance_tags_all"></a> [ec2\_spot\_instance\_tags\_all](#output\_ec2\_spot\_instance\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider default\_tags configuration block |
 | <a name="output_ec2_t2_unlimited_arn"></a> [ec2\_t2\_unlimited\_arn](#output\_ec2\_t2\_unlimited\_arn) | The ARN of the instance |
+| <a name="output_ec2_t2_unlimited_availability_zone"></a> [ec2\_t2\_unlimited\_availability\_zone](#output\_ec2\_t2\_unlimited\_availability\_zone) | The availability zone of the created instance |
 | <a name="output_ec2_t2_unlimited_capacity_reservation_specification"></a> [ec2\_t2\_unlimited\_capacity\_reservation\_specification](#output\_ec2\_t2\_unlimited\_capacity\_reservation\_specification) | Capacity reservation specification of the instance |
 | <a name="output_ec2_t2_unlimited_id"></a> [ec2\_t2\_unlimited\_id](#output\_ec2\_t2\_unlimited\_id) | The ID of the instance |
 | <a name="output_ec2_t2_unlimited_instance_state"></a> [ec2\_t2\_unlimited\_instance\_state](#output\_ec2\_t2\_unlimited\_instance\_state) | The state of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped` |
@@ -107,6 +109,7 @@ No inputs.
 | <a name="output_ec2_t2_unlimited_public_ip"></a> [ec2\_t2\_unlimited\_public\_ip](#output\_ec2\_t2\_unlimited\_public\_ip) | The public IP address assigned to the instance, if applicable. NOTE: If you are using an aws\_eip with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached |
 | <a name="output_ec2_t2_unlimited_tags_all"></a> [ec2\_t2\_unlimited\_tags\_all](#output\_ec2\_t2\_unlimited\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider default\_tags configuration block |
 | <a name="output_ec2_t3_unlimited_arn"></a> [ec2\_t3\_unlimited\_arn](#output\_ec2\_t3\_unlimited\_arn) | The ARN of the instance |
+| <a name="output_ec2_t3_unlimited_availability_zone"></a> [ec2\_t3\_unlimited\_availability\_zone](#output\_ec2\_t3\_unlimited\_availability\_zone) | The availability zone of the created instance |
 | <a name="output_ec2_t3_unlimited_capacity_reservation_specification"></a> [ec2\_t3\_unlimited\_capacity\_reservation\_specification](#output\_ec2\_t3\_unlimited\_capacity\_reservation\_specification) | Capacity reservation specification of the instance |
 | <a name="output_ec2_t3_unlimited_id"></a> [ec2\_t3\_unlimited\_id](#output\_ec2\_t3\_unlimited\_id) | The ID of the instance |
 | <a name="output_ec2_t3_unlimited_instance_state"></a> [ec2\_t3\_unlimited\_instance\_state](#output\_ec2\_t3\_unlimited\_instance\_state) | The state of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped` |
@@ -116,6 +119,7 @@ No inputs.
 | <a name="output_ec2_t3_unlimited_public_ip"></a> [ec2\_t3\_unlimited\_public\_ip](#output\_ec2\_t3\_unlimited\_public\_ip) | The public IP address assigned to the instance, if applicable. NOTE: If you are using an aws\_eip with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached |
 | <a name="output_ec2_t3_unlimited_tags_all"></a> [ec2\_t3\_unlimited\_tags\_all](#output\_ec2\_t3\_unlimited\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider default\_tags configuration block |
 | <a name="output_spot_bid_status"></a> [spot\_bid\_status](#output\_spot\_bid\_status) | The current bid status of the Spot Instance Request |
+| <a name="output_spot_instance_availability_zone"></a> [spot\_instance\_availability\_zone](#output\_spot\_instance\_availability\_zone) | The availability zone of the created spot instance |
 | <a name="output_spot_instance_id"></a> [spot\_instance\_id](#output\_spot\_instance\_id) | The Instance ID (if any) that is currently fulfilling the Spot Instance request |
 | <a name="output_spot_request_state"></a> [spot\_request\_state](#output\_spot\_request\_state) | The current request state of the Spot Instance Request |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -89,6 +89,11 @@ output "ec2_complete_ephemeral_block_device" {
   value       = module.ec2_complete.ephemeral_block_device
 }
 
+output "ec2_complete_availability_zone" {
+  description = "The availability zone of the created instance"
+  value       = module.ec2_complete.availability_zone
+}
+
 # EC2 T2 Unlimited
 output "ec2_t2_unlimited_id" {
   description = "The ID of the instance"
@@ -135,6 +140,11 @@ output "ec2_t2_unlimited_tags_all" {
   value       = module.ec2_t2_unlimited.tags_all
 }
 
+output "ec2_t2_unlimited_availability_zone" {
+  description = "The availability zone of the created instance"
+  value       = module.ec2_t2_unlimited.availability_zone
+}
+
 # EC2 T3 Unlimited
 output "ec2_t3_unlimited_id" {
   description = "The ID of the instance"
@@ -179,6 +189,11 @@ output "ec2_t3_unlimited_public_ip" {
 output "ec2_t3_unlimited_tags_all" {
   description = "A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block"
   value       = module.ec2_t3_unlimited.tags_all
+}
+
+output "ec2_t3_unlimited_availability_zone" {
+  description = "The availability zone of the created instance"
+  value       = module.ec2_t3_unlimited.availability_zone
 }
 
 # EC2 with ignore AMI changes
@@ -252,4 +267,9 @@ output "spot_request_state" {
 output "spot_instance_id" {
   description = "The Instance ID (if any) that is currently fulfilling the Spot Instance request"
   value       = module.ec2_spot_instance.spot_instance_id
+}
+
+output "spot_instance_availability_zone" {
+  description = "The availability zone of the created spot instance"
+  value       = module.ec2_spot_instance.availability_zone
 }

--- a/examples/volume-attachment/README.md
+++ b/examples/volume-attachment/README.md
@@ -56,6 +56,7 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | <a name="output_ec2_arn"></a> [ec2\_arn](#output\_ec2\_arn) | The ARN of the instance |
+| <a name="output_ec2_availability_zone"></a> [ec2\_availability\_zone](#output\_ec2\_availability\_zone) | The availability zone of the created spot instance |
 | <a name="output_ec2_capacity_reservation_specification"></a> [ec2\_capacity\_reservation\_specification](#output\_ec2\_capacity\_reservation\_specification) | Capacity reservation specification of the instance |
 | <a name="output_ec2_id"></a> [ec2\_id](#output\_ec2\_id) | The ID of the instance |
 | <a name="output_ec2_instance_state"></a> [ec2\_instance\_state](#output\_ec2\_instance\_state) | The state of the instance. One of: `pending`, `running`, `shutting-down`, `terminated`, `stopping`, `stopped` |

--- a/examples/volume-attachment/main.tf
+++ b/examples/volume-attachment/main.tf
@@ -44,7 +44,7 @@ resource "aws_volume_attachment" "this" {
 }
 
 resource "aws_ebs_volume" "this" {
-  availability_zone = element(local.azs, 0)
+  availability_zone = module.ec2.availability_zone
   size              = 1
 
   tags = local.tags

--- a/examples/volume-attachment/outputs.tf
+++ b/examples/volume-attachment/outputs.tf
@@ -43,3 +43,8 @@ output "ec2_tags_all" {
   description = "A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block"
   value       = module.ec2.tags_all
 }
+
+output "ec2_availability_zone" {
+  description = "The availability zone of the created spot instance"
+  value       = module.ec2.availability_zone
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -153,6 +153,16 @@ output "ami" {
   )
 }
 
+output "availability_zone" {
+  description = "The availability zone of the created instance"
+  value = try(
+    aws_instance.this[0].availability_zone,
+    aws_instance.ignore_ami[0].availability_zone,
+    aws_spot_instance_request.this[0].availability_zone,
+    null,
+  )
+}
+
 ################################################################################
 # IAM Role / Instance Profile
 ################################################################################


### PR DESCRIPTION
## Description
Added `availability_zone` output. The `availability_zone` of the created instance is useful information to use outside of the module. 

## Motivation and Context
When creating multiple EC2 instances in multiple AZs, in most cases, we would like to have the EBS volume in the same AZ as the created EC2. As a trick we can use `data.aws_instance` with loop or a map of AZs and `random_suffle`,
but it does not look nice. In my opinion having `availability_zone` output would get out of tricks and make the code cleaner and easier to read.

This PR resolves #341 and #264

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
Deployed `volume-attachment` example:

```hcl
terraform plan --target module.ec2 --target aws_volume_attachment.this --target aws_ebs_volume.this

  # aws_ebs_volume.this will be created
  + resource "aws_ebs_volume" "this" {
      + arn               = (known after apply)
      + availability_zone = "eu-west-1c"
      + encrypted         = (known after apply)
      + final_snapshot    = false
      + id                = (known after apply)
      + iops              = (known after apply)
      + kms_key_id        = (known after apply)
      + size              = 1
      + snapshot_id       = (known after apply)
      + tags              = {
          + "Example"    = "ex-volume-attachment"
          + "Name"       = "ex-volume-attachment"
          + "Repository" = "https://github.com/terraform-aws-modules/terraform-aws-ec2-instance"
        }
      + tags_all          = {
          + "Example"    = "ex-volume-attachment"
          + "Name"       = "ex-volume-attachment"
          + "Repository" = "https://github.com/terraform-aws-modules/terraform-aws-ec2-instance"
        }
      + throughput        = (known after apply)
      + type              = (known after apply)
    }

  # aws_volume_attachment.this will be created
  + resource "aws_volume_attachment" "this" {
      + device_name = "/dev/sdh"
      + id          = (known after apply)
      + instance_id = (known after apply)
      + volume_id   = (known after apply)
    }

  # module.ec2.aws_instance.this[0] will be created
  + resource "aws_instance" "this" {
      + ami                                  = "ami-0c43c11b9446e99da"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = true
      + availability_zone                    = "eu-west-1c"
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_lifecycle                   = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "c5.large"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = (known after apply)
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + spot_instance_request_id             = (known after apply)
      + subnet_id                            = "subnet-****"
      + tags                                 = {
          + "Example"    = "ex-volume-attachment"
          + "Name"       = "ex-volume-attachment"
          + "Repository" = "https://github.com/terraform-aws-modules/terraform-aws-ec2-instance"
        }
      + tags_all                             = {
          + "Example"    = "ex-volume-attachment"
          + "Name"       = "ex-volume-attachment"
          + "Repository" = "https://github.com/terraform-aws-modules/terraform-aws-ec2-instance"
        }
      + tenancy                              = (known after apply)
      + user_data                            = (known after apply)
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + volume_tags                          = {
          + "Name" = "ex-volume-attachment"
        }
      + vpc_security_group_ids               = (known after apply)

      + credit_specification {}

      + enclave_options {
          + enabled = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = "enabled"
          + http_put_response_hop_limit = 1
          + http_tokens                 = "optional"
          + instance_metadata_tags      = (known after apply)
        }

      + timeouts {}
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + ec2_arn                                = (known after apply)
  + ec2_availability_zone                  = "eu-west-1c"
  + ec2_capacity_reservation_specification = (known after apply)
  + ec2_id                                 = (known after apply)
  + ec2_instance_state                     = (known after apply)
  + ec2_primary_network_interface_id       = (known after apply)
  + ec2_private_dns                        = (known after apply)
  + ec2_public_dns                         = (known after apply)
  + ec2_public_ip                          = (known after apply)
  + ec2_tags_all                           = {
      + Example    = "ex-volume-attachment"
      + Name       = "ex-volume-attachment"
      + Repository = "https://github.com/terraform-aws-modules/terraform-aws-ec2-instance"
    }
```
- [x] I have executed `pre-commit run -a` on my pull request