### PR TITLE
feat: Remove call data ssm parameter when ami id is specified

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 data "aws_ssm_parameter" "this" {
-  count = local.create ? 1 : 0
+  count = local.create && var.ami == null ? 1 : 0
 
   name = var.ami_ssm_parameter
 }


### PR DESCRIPTION
#350  Description: 
## Description

Create an ec2 instance without ssm permission with cause error.

This account or role can still create an instance in console.

The root cause is because this line of code in main.tf in line 9:

```
data "aws_ssm_parameter" "this" {
  count = local.create ? 1 : 0

  name = var.ami_ssm_parameter
}
```

Request to make the call data aws_ssm_parameter optional, something like when ami is specified, then no need to call ssm parameter to get the ami id: 
```
#main.tf
  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
```

Because it coalesce the `var.ami` and the `nonsensitive(data.aws_ssm_parameter.this[0].value))`, so we only need it when `var.ami` is not specified. So it should be check for null when use data to call to ssm.

```
data "aws_ssm_parameter" "this" {
  count = local.create && var.ami == null ? 1 : 0

  name = var.ami_ssm_parameter
}
```

## ⚠️ Note


## Versions

- Module version [Required]: 5.2.1

- Terraform version: any version
- Provider version(s): any version
<!-- Execute: terraform providers -version -->

## Reproduction Code [Required]

<!-- REQUIRED -->

Steps to reproduce the behavior:
- Create an account or role with ec2 permission only
- Use terraform to plan resource with "terraform-aws-modules/ec2-instance/aws" module
- Error!

<!-- Are you using workspaces? -->
<!-- Have you cleared the local cache (see Notice section above)? -->
<!-- List steps in order that led up to the issue you encountered -->

## Expected behavior

Create an instance without ssm parameter permission
<!-- A clear and concise description of what you expected to happen -->


## Actual behavior

Cannot create instance because missing permission
<!-- A clear and concise description of what actually happened -->

