### PR TITLE
fix: Modify coalesce ami and ami_ssm_parameter function from always failing when ami var defined

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ data "aws_ssm_parameter" "this" {
 resource "aws_instance" "this" {
   count = local.create && !var.ignore_ami_changes && !var.create_spot_instance ? 1 : 0
 
-  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
+  ami                  = try(coalesce(try(var.ami, null), try(nonsensitive(data.aws_ssm_parameter.this[0].value), null), null))
   instance_type        = var.instance_type
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core
@@ -187,7 +187,7 @@ resource "aws_instance" "this" {
 resource "aws_instance" "ignore_ami" {
   count = local.create && var.ignore_ami_changes && !var.create_spot_instance ? 1 : 0
 
-  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
+  ami                  = try(coalesce(try(var.ami, null), try(nonsensitive(data.aws_ssm_parameter.this[0].value), null), null))
   instance_type        = var.instance_type
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core
@@ -361,7 +361,7 @@ resource "aws_instance" "ignore_ami" {
 resource "aws_spot_instance_request" "this" {
   count = local.create && var.create_spot_instance ? 1 : 0
 
-  ami                  = try(coalesce(var.ami, nonsensitive(data.aws_ssm_parameter.this[0].value)), null)
+  ami                  = try(coalesce(try(var.ami, null), try(nonsensitive(data.aws_ssm_parameter.this[0].value), null), null))
   instance_type        = var.instance_type
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core


### PR DESCRIPTION
… always failing when ami var defined

## Description
<!--- Describe your changes in detail -->
Include separate try functions for both `var.ami` and `nonsensitive(data.aws_ssm_parameter.this[0].value)` to allow them to return null separately instead of returning null if the whole expression fails

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Change is required to fix #352 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s) (Note: I don't believe I need to make any changes to the examples for this PR)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
