### PR TITLE
feat: new param `instance_state`

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ No modules.
 | <a name="input_instance_initiated_shutdown_behavior"></a> [instance\_initiated\_shutdown\_behavior](#input\_instance\_initiated\_shutdown\_behavior) | Shutdown behavior for the instance. Amazon defaults this to stop for EBS-backed instances and terminate for instance-store instances. Cannot be set on instance-store instance | `string` | `null` | no |
 | <a name="input_instance_tags"></a> [instance\_tags](#input\_instance\_tags) | Additional tags for the instance | `map(string)` | `{}` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance to start | `string` | `"t3.micro"` | no |
+| <a name="input_instance_state"></a> [instance\_type](#input\_instance\_state) | The type of instance to start | `string` | `"running"` | no |
 | <a name="input_ipv6_address_count"></a> [ipv6\_address\_count](#input\_ipv6\_address\_count) | A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet | `number` | `null` | no |
 | <a name="input_ipv6_addresses"></a> [ipv6\_addresses](#input\_ipv6\_addresses) | Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `null` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ No modules.
 | <a name="input_instance_initiated_shutdown_behavior"></a> [instance\_initiated\_shutdown\_behavior](#input\_instance\_initiated\_shutdown\_behavior) | Shutdown behavior for the instance. Amazon defaults this to stop for EBS-backed instances and terminate for instance-store instances. Cannot be set on instance-store instance | `string` | `null` | no |
 | <a name="input_instance_tags"></a> [instance\_tags](#input\_instance\_tags) | Additional tags for the instance | `map(string)` | `{}` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The state of the instance | `string` | `"t3.micro"` | no |
-| <a name="input_instance_state"></a> [instance\_type](#input\_instance\_state) | The type of instance to start | `string` | `"running"` | no |
+| <a name="input_instance_state"></a> [instance\_state](#input\_instance\_state) | The type of instance to start | `string` | `"running"` | no |
 | <a name="input_ipv6_address_count"></a> [ipv6\_address\_count](#input\_ipv6\_address\_count) | A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet | `number` | `null` | no |
 | <a name="input_ipv6_addresses"></a> [ipv6\_addresses](#input\_ipv6\_addresses) | Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `null` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ No modules.
 | <a name="input_ignore_ami_changes"></a> [ignore\_ami\_changes](#input\_ignore\_ami\_changes) | Whether changes to the AMI ID changes should be ignored by Terraform. Note - changing this value will result in the replacement of the instance | `bool` | `false` | no |
 | <a name="input_instance_initiated_shutdown_behavior"></a> [instance\_initiated\_shutdown\_behavior](#input\_instance\_initiated\_shutdown\_behavior) | Shutdown behavior for the instance. Amazon defaults this to stop for EBS-backed instances and terminate for instance-store instances. Cannot be set on instance-store instance | `string` | `null` | no |
 | <a name="input_instance_tags"></a> [instance\_tags](#input\_instance\_tags) | Additional tags for the instance | `map(string)` | `{}` | no |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance to start | `string` | `"t3.micro"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The state of the instance | `string` | `"t3.micro"` | no |
 | <a name="input_instance_state"></a> [instance\_type](#input\_instance\_state) | The type of instance to start | `string` | `"running"` | no |
 | <a name="input_ipv6_address_count"></a> [ipv6\_address\_count](#input\_ipv6\_address\_count) | A number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet | `number` | `null` | no |
 | <a name="input_ipv6_addresses"></a> [ipv6\_addresses](#input\_ipv6\_addresses) | Specify one or more IPv6 addresses from the range of the subnet to associate with the primary network interface | `list(string)` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -34,6 +34,7 @@ module "ec2_complete" {
 
   ami                         = data.aws_ami.amazon_linux.id
   instance_type               = "c5.xlarge" # used to set core count below
+  instance_state              = "running"   # ensure instance is running
   availability_zone           = element(module.vpc.azs, 0)
   subnet_id                   = element(module.vpc.private_subnets, 0)
   vpc_security_group_ids      = [module.security_group.security_group_id]

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "this" {
 
   ami                  = local.ami
   instance_type        = var.instance_type
+  instance_state       = var.instance_state
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core
   hibernation          = var.hibernation
@@ -191,6 +192,7 @@ resource "aws_instance" "ignore_ami" {
 
   ami                  = local.ami
   instance_type        = var.instance_type
+  instance_state       = var.instance_state
   cpu_core_count       = var.cpu_core_count
   cpu_threads_per_core = var.cpu_threads_per_core
   hibernation          = var.hibernation

--- a/variables.tf
+++ b/variables.tf
@@ -124,6 +124,12 @@ variable "instance_type" {
   default     = "t3.micro"
 }
 
+variable "instance_state" {
+  description = "The state of the instance"
+  type        = string
+  default     = "running" # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#instance_state
+}
+
 variable "instance_tags" {
   description = "Additional tags for the instance"
   type        = map(string)


### PR DESCRIPTION
## Description
introduce new param `instance_state` to control state of instance https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#instance_state

## Motivation and Context
we want to turn off instance without impacting run of state

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
