### PR TITLE
chore: Mark http_tokens required by default for imdsv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ No modules.
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |
 | <a name="input_launch_template"></a> [launch\_template](#input\_launch\_template) | Specifies a Launch Template to configure the instance. Parameters configured on this resource will override the corresponding parameters in the Launch Template | `map(string)` | `{}` | no |
 | <a name="input_maintenance_options"></a> [maintenance\_options](#input\_maintenance\_options) | The maintenance options for the instance | `any` | `{}` | no |
-| <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Customize the metadata options of the instance | `map(string)` | <pre>{<br>  "http_endpoint": "enabled",<br>  "http_put_response_hop_limit": 1,<br>  "http_tokens": "optional"<br>}</pre> | no |
+| <a name="input_metadata_options"></a> [metadata\_options](#input\_metadata\_options) | Customize the metadata options of the instance | `map(string)` | <pre>{<br>  "http_endpoint": "enabled",<br>  "http_put_response_hop_limit": 1,<br>  "http_tokens": "required"<br>}</pre> | no |
 | <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on EC2 instance created | `string` | `""` | no |
 | <a name="input_network_interface"></a> [network\_interface](#input\_network\_interface) | Customize network interfaces to be attached at instance boot time | `list(map(string))` | `[]` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -160,7 +160,7 @@ variable "metadata_options" {
   default = {
     "http_endpoint"               = "enabled"
     "http_put_response_hop_limit" = 1
-    "http_tokens"                 = "optional"
+    "http_tokens"                 = "required"
   }
 }
 

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -45,7 +45,7 @@ module "wrapper" {
   metadata_options = try(each.value.metadata_options, var.defaults.metadata_options, {
     "http_endpoint"               = "enabled"
     "http_put_response_hop_limit" = 1
-    "http_tokens"                 = "optional"
+    "http_tokens"                 = "required"
   })
   monitoring                          = try(each.value.monitoring, var.defaults.monitoring, null)
   name                                = try(each.value.name, var.defaults.name, "")


### PR DESCRIPTION
## Description

mark http_tokens required by default for imdsv2

- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-v2-how-it-works.html
- https://aws.amazon.com/blogs/security/get-the-full-benefits-of-imdsv2-and-disable-imdsv1-across-your-aws-infrastructure/

<img width="586" alt="image" src="https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/assets/1580956/ca466e8d-c62a-4b04-bf86-7cd78e045920">



## Motivation and Context

AWS is deprecating imdsv1, and http_tokens required is needed for imdsv2

## Breaking Changes

This is metadata setup, I dont foresee it would break anything.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
