### PR TITLE
feat: Add support for capacity block 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -171,7 +171,6 @@ resource "aws_instance" "this" {
 
   content {
     market_type  = try(instance_market_options.value.market_type, null)
-    spot_options = try(instance_market_options.value.spot_options, null)
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -167,12 +167,12 @@ resource "aws_instance" "this" {
   }
 
   dynamic "instance_market_options" {
-  for_each = length(var.instance_market_options) > 0 ? [var.instance_market_options] : []
+    for_each = length(var.instance_market_options) > 0 ? [var.instance_market_options] : []
 
-  content {
-    market_type  = try(instance_market_options.value.market_type, null)
+    content {
+      market_type = try(instance_market_options.value.market_type, null)
+    }
   }
-}
 
   enclave_options {
     enabled = var.enclave_options_enabled

--- a/main.tf
+++ b/main.tf
@@ -166,6 +166,15 @@ resource "aws_instance" "this" {
     }
   }
 
+  dynamic "instance_market_options" {
+  for_each = length(var.instance_market_options) > 0 ? [var.instance_market_options] : []
+
+  content {
+    market_type  = try(instance_market_options.value.market_type, null)
+    spot_options = try(instance_market_options.value.spot_options, null)
+  }
+}
+
   enclave_options {
     enabled = var.enclave_options_enabled
   }

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,12 @@ variable "maintenance_options" {
   default     = {}
 }
 
+variable "instance_market_options" {
+  description = "The market (purchasing) option for the instance"
+  type        = any
+  default     = {}
+}
+
 variable "availability_zone" {
   description = "AZ to start the instance in"
   type        = string


### PR DESCRIPTION
## Description
In the ec2-instance template terraform, I add the ability to assign `instance_market_options`. 

## Motivation and Context
When I tried to deploy an EC2 instance into a capacity block, I got this error
```
│ Error: creating EC2 Instance: InvalidParameterValue: The market type (purchasing) option is not valid. Choose a different market type and try again
```
I found this [github issue](https://github.com/terraform-aws-modules/terraform-aws-ec2-instance/issues/383) which contained most of what I needed to fix this error.

## Breaking Changes
This should not have any breaking changes since it adds optional functionality.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
I tested this change on our private repository where I deployed an EC2 instance into a capacity block.
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
