### PR TITLE
fix: Add backward compatibility after provider major update

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66"
+      version = "~> 5.100.0" # ">= 5.100.0, < 6.0.0"
     }
   }
 }


### PR DESCRIPTION
Fix errors in ec2 modules due to 6.x release of providers