### PR TITLE
fix: Lower minimum Terraform version to 1.5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ module "ec2_instance" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which can cost money. Run `terraform
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.10"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {

--- a/examples/session-manager/README.md
+++ b/examples/session-manager/README.md
@@ -29,7 +29,7 @@ Note that this example may create resources which can cost money. Run `terraform
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers

--- a/examples/session-manager/versions.tf
+++ b/examples/session-manager/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.10"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.10"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.10"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Lower the Terraform version to 1.5.7 to avoid forcing anyone to reread the HashiCorp license agreement, only to find out they can still use a recent version of Terraform.