### PR TITLE
Fixed Description for variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -563,7 +563,7 @@ variable "security_group_egress_rules" {
 }
 
 variable "security_group_ingress_rules" {
-  description = "Egress rules to add to the security group"
+  description = "Ingress rules to add to the security group"
   type = map(object({
     cidr_ipv4                    = optional(string)
     cidr_ipv6                    = optional(string)


### PR DESCRIPTION
Fixed description for "security_group_ingress_rules"

## Description
There was propably a copy and paste mistake in the description of the security group ingress rules variable.

## Motivation and Context
This fix helps to understand what the variable is used for.

## Breaking Changes
No breaking changes, just cosmetics.
