### PR TITLE
fix: Avoid setting `Name` tag when a value has not been provided for `name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ module "ec2_instance" {
 
   name = "single-instance"
 
-  instance_type = "t2.micro"
+  instance_type = "t3.micro"
   key_name      = "user1"
   monitoring    = true
   subnet_id     = "subnet-eddcdzz4"
@@ -36,7 +36,7 @@ module "ec2_instance" {
 
   name = "instance-${each.key}"
 
-  instance_type = "t2.micro"
+  instance_type = "t3.micro"
   key_name      = "user1"
   monitoring    = true
   subnet_id     = "subnet-eddcdzz4"
@@ -60,7 +60,7 @@ module "ec2_instance" {
   spot_price           = "0.60"
   spot_type            = "persistent"
 
-  instance_type = "t2.micro"
+  instance_type = "t3.micro"
   key_name      = "user1"
   monitoring    = true
   subnet_id     = "subnet-eddcdzz4"

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
   instance_tags = merge(
     var.tags,
     var.instance_tags,
-    { "Name" = var.name },
+    var.name != "" ? { "Name" = var.name } : {}
   )
 
   instance_id = try(


### PR DESCRIPTION
## Description
- Set Name tag to var.name if it is not "", otherwise use tags
- Minor change to README file, encourage users to use t3 instead of super old t2 instance type.

## Motivation and Context
- Resolves #442 

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
