### PR TITLE
feat: Add name and instance_type as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ No modules.
 |------|-------------|
 | <a name="output_ami"></a> [ami](#output\_ami) | AMI ID that was used to create the instance |
 | <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the instance |
+| <a name="output_name"></a> [name](#output\_name) | The name of the instance |
+| <a name="output_instance_type"></a> [instance_type](#output\_instance_type) | The type of the instance |
 | <a name="output_availability_zone"></a> [availability\_zone](#output\_availability\_zone) | The availability zone of the created instance |
 | <a name="output_capacity_reservation_specification"></a> [capacity\_reservation\_specification](#output\_capacity\_reservation\_specification) | Capacity reservation specification of the instance |
 | <a name="output_ebs_block_device"></a> [ebs\_block\_device](#output\_ebs\_block\_device) | EBS block device information |

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,16 @@ output "arn" {
   )
 }
 
+output "name" {
+  description = "The name of the instance"
+  value = var.name
+}
+
+output "instance_type" {
+  description = "The type of the instance"
+  value = var.instance_type
+}
+
 output "capacity_reservation_specification" {
   description = "Capacity reservation specification of the instance"
   value = try(


### PR DESCRIPTION
## Description
Added Instance name and Instance type to module outputs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since these output for Instance is missing, we can't directly refer to the module to fetch these Information and make it as input of another module. To fetch it requires additional actions.
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None, module logic untouched.

