### PR TITLE
fix: Use computed `local.security_group_name` in the security group `Name` tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -776,7 +776,7 @@ resource "aws_vpc_security_group_egress_rule" "this" {
   tags = merge(
     var.tags,
     var.security_group_tags,
-    { "Name" = "${var.name}-${each.key}" },
+    { "Name" = "${local.security_group_name}-${each.key}" },
     each.value.tags,
   )
 
@@ -800,7 +800,7 @@ resource "aws_vpc_security_group_ingress_rule" "this" {
   tags = merge(
     var.tags,
     var.security_group_tags,
-    { "Name" = "${var.name}-${each.key}" },
+    { "Name" = "${local.security_group_name}-${each.key}" },
     each.value.tags,
   )
 


### PR DESCRIPTION
## Description
We should used the already computed `local.security_group_name` instead of `var.name` in security group rule name tag.

## Motivation and Context
Its safer to use the local so if the user has decided to set a different name on SG than the EC2 stack.
```hcl
security_group_name   = try(coalesce(var.security_group_name, var.name), "")
```
We are already using it for the SG name tag:
```hcl
 tags = merge(
    var.tags,
    { "Name" = local.security_group_name },
    var.security_group_tags
  )
```
but not on the rules. This will harmonize that too.

## Breaking Changes
No breaking changes