### PR TITLE
fix: Always pull a value from SSM data source since a computed value cannot be used in conditional logic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
 
   is_t_instance_type = replace(var.instance_type, "/^t(2|3|3a|4g){1}\\..*$/", "1") == "1" ? true : false
 
-  ami = try(coalesce(var.ami, try(nonsensitive(data.aws_ssm_parameter.this[0].value), null)), null)
+  ami = try(coalesce(var.ami, try(nonsensitive(data.aws_ssm_parameter.this.value), null)), null)
 
   instance_tags = merge(
     var.tags,
@@ -29,8 +29,6 @@ locals {
 }
 
 data "aws_ssm_parameter" "this" {
-  count = local.create && var.ami == null ? 1 : 0
-
   region = var.region
 
   name = var.ami_ssm_parameter


### PR DESCRIPTION
Updated the data source reference for the SSM parameter and modified the count condition.

## Description

Fixes #465 

## Motivation and Context

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request

