### PR TITLE
feat: Add eni_tags to tag primary network interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_ebs_volume.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
+| [aws_ec2_tag.eni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
+| [aws_ec2_tag.eni_ignore_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
 | [aws_ec2_tag.spot_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
 | [aws_eip.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
@@ -222,6 +224,7 @@ No modules.
 | <a name="input_enable_primary_ipv6"></a> [enable\_primary\_ipv6](#input\_enable\_primary\_ipv6) | Whether to assign a primary IPv6 Global Unicast Address (GUA) to the instance when launched in a dual-stack or IPv6-only subnet | `bool` | `null` | no |
 | <a name="input_enable_volume_tags"></a> [enable\_volume\_tags](#input\_enable\_volume\_tags) | Whether to enable volume tags (if enabled it conflicts with root\_block\_device tags) | `bool` | `true` | no |
 | <a name="input_enclave_options_enabled"></a> [enclave\_options\_enabled](#input\_enclave\_options\_enabled) | Whether Nitro Enclaves will be enabled on the instance. Defaults to `false` | `bool` | `null` | no |
+| <a name="input_eni_tags"></a> [eni\_tags](#input\_eni\_tags) | A map of additional tags to add to the primary network interface (ENI) of the instance | `map(string)` | `{}` | no |
 | <a name="input_ephemeral_block_device"></a> [ephemeral\_block\_device](#input\_ephemeral\_block\_device) | Customize Ephemeral (also known as Instance Store) volumes on the instance | <pre>map(object({<br/>    device_name  = string<br/>    no_device    = optional(bool)<br/>    virtual_name = optional(string)<br/>  }))</pre> | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Destroys instance even if `disable_api_termination` or `disable_api_stop` is set to true. Once this parameter is set to true, a successful terraform apply run before a destroy is required to update this value in the resource state. Without a successful terraform apply after this parameter is set, this flag will have no effect. If setting this field in the same operation that would require replacing the instance or destroying the instance, this flag will not work. Additionally when importing an instance, a successful terraform apply is required to set this value in state before it will take effect on a destroy operation. | `bool` | `null` | no |
 | <a name="input_get_password_data"></a> [get\_password\_data](#input\_get\_password\_data) | If true, wait for password data to become available and retrieve it | `bool` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,11 @@ locals {
     var.name != "" ? { "Name" = var.name } : {}
   )
 
+  eni_tags = merge(
+    local.instance_tags,
+    var.eni_tags,
+  )
+
   instance_id = try(
     aws_instance.this[0].id,
     aws_instance.ignore_ami[0].id,
@@ -654,6 +659,22 @@ resource "aws_ec2_tag" "spot_instance" {
   for_each = local.create && var.create_spot_instance ? local.instance_tags : {}
 
   resource_id = aws_spot_instance_request.this[0].spot_instance_id
+  key         = each.key
+  value       = each.value
+}
+
+resource "aws_ec2_tag" "eni" {
+  for_each = local.create && !var.ignore_ami_changes && !var.create_spot_instance ? local.eni_tags : {}
+
+  resource_id = aws_instance.this[0].primary_network_interface_id
+  key         = each.key
+  value       = each.value
+}
+
+resource "aws_ec2_tag" "eni_ignore_ami" {
+  for_each = local.create && var.ignore_ami_changes && !var.create_spot_instance ? local.eni_tags : {}
+
+  resource_id = aws_instance.ignore_ami[0].primary_network_interface_id
   key         = each.key
   value       = each.value
 }

--- a/variables.tf
+++ b/variables.tf
@@ -343,6 +343,12 @@ variable "instance_tags" {
   default     = {}
 }
 
+variable "eni_tags" {
+  description = "A map of additional tags to add to the primary network interface (ENI) of the instance"
+  type        = map(string)
+  default     = {}
+}
+
 variable "tenancy" {
   description = "The tenancy of the instance (if the instance is running in a VPC). Available values: default, dedicated, host"
   type        = string


### PR DESCRIPTION
Closes #476

AWS auto-creates an ENI when you launch an EC2 instance, but the module doesn't tag it. So you end up with a heavily tagged instance and a bare-looking ENI sitting next to it in the console. This adds an `eni_tags` variable to fix that.

## What's in here

- **`eni_tags` variable** — map of tags, defaults to `{}`
- **`local.eni_tags`** — merges `local.instance_tags` with `var.eni_tags`, so the ENI inherits whatever the instance already has, and `eni_tags` is just extra on top
- **Two `aws_ec2_tag` resources** — one for `aws_instance.this`, one for `aws_instance.ignore_ami`. Same count conditions as their parent so they only run when they should

Skipped spot instances — `aws_spot_instance_request` doesn't expose `primary_network_interface_id`, and the existing `aws_ec2_tag.spot_instance` already covers that path.

## Not breaking anything

Default is `{}`, so existing users notice nothing. New resources only spin up if their parent instance does and `local.eni_tags` actually has stuff in it.

## Tested

- `terraform init -backend=false` ✅
- `terraform validate` ✅
- README regenerated via `terraform-docs`